### PR TITLE
feat(session): add cross-process concurrency control to session storage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,11 @@ build/
 .pytest_cache/
 .github/obo_sessions/**
 /tmp/
+
+# Cross-process lock file for session storage; runtime state, never committed.
+# Session files themselves ARE tracked, so this cannot rely on ignoring the
+# sessions directory as a whole.
+.oboe.lock
+**/.oboe.lock
+# Temp files from interrupted atomic writes (normally removed automatically).
+.*.json.*.tmp

--- a/README.md
+++ b/README.md
@@ -191,6 +191,45 @@ Common pairings:
 - Approve Delayed: call `oboe_set_approval(..., approval_status="approved", approval_mode="delayed")`; this records delayed approval and moves the item to `deferred`
 - Deny: set `approval_status=denied`; if the item is being closed out of the queue, pair it with `status=skipped`
 
+## Concurrency
+
+Session files are shared state. The MCP server, `oboe-cli`, a second editor
+window, and any script you run can all reach the same
+`.github/oboe_sessions/` directory at once, so every operation takes a
+cross-process lock over that directory.
+
+**What you get:**
+
+- A mutation writes the session file and `index.json` under a single held
+  lock, so the two never drift apart, and an error mid-operation writes
+  nothing at all.
+- Writes are atomic (temp file + rename). A reader never sees a truncated or
+  half-written file.
+- Readers take a *shared* lock, so concurrent reads do not block each other.
+  Writers are exclusive.
+
+**Choosing what happens when the lock is held.** The default is to wait up to
+30 seconds and then raise an error naming the lock file and its recorded
+holder. An agent that would rather retry later than stall can ask to fail
+immediately instead:
+
+| Surface | Wait longer | Fail immediately |
+|---|---|---|
+| MCP | `oboe_set_lock_policy(timeout_seconds=120)` | `oboe_set_lock_policy(blocking=false)` |
+| CLI | `oboe-cli --lock-timeout 120 …` | `oboe-cli --lock-fail-fast …` |
+| Environment | `OBOE_LOCK_TIMEOUT=120` | `OBOE_LOCK_POLICY=fail-fast` |
+
+Pass `--lock-timeout none` (or `OBOE_LOCK_TIMEOUT=none`) to wait indefinitely.
+Be aware that a wedged holder will then hang the call with no diagnostic,
+which is why it is not the default. `oboe_get_lock_policy` reports what is
+currently in effect.
+
+**Platform note.** POSIX uses `fcntl.flock`. Elsewhere a portable lockfile
+fallback is used which cannot express shared mode, so readers are serialized
+along with writers; `oboe_get_lock_policy` reports this as
+`concurrent_readers: false`. The lock file is `.oboe.lock` inside the sessions
+directory and should not be committed.
+
 ## Interaction Modes
 
 The three common interaction patterns are plain chat, a structured question tool, and a full OBO session. They solve different problems.

--- a/docs/concurrency-handoff.md
+++ b/docs/concurrency-handoff.md
@@ -1,0 +1,100 @@
+# Handoff: Add Concurrency Control to oboe-mcp / oboe-cli
+
+## The Problem
+
+Session state is stored as flat JSON files (`session_*.json` + `index.json`) with **zero concurrency protection**. Every mutation follows a naive read-modify-write pattern:
+
+```python
+session = load_session(file)   # READ
+... modify dict ...            # MODIFY (in memory)
+save_session(file, session)    # WRITE (truncates + writes entire file)
+_upsert_index(...)             # WRITE (separate file, separate call)
+```
+
+This is safe only under single-process access. Concurrent access is not theoretical — it arises from:
+
+- Multiple VS Code windows targeting the same project
+- VS Code (via MCP server) + CLI running simultaneously
+- Parallel CLI invocations (automation, scripts)
+- `mcp.run()` processing sequential requests on a single stdio connection, but **multiple MCP client connections** are possible
+
+## Verified Risks
+
+1. **Lost updates (critical):** Process A loads session, Process B loads session, A writes item 1→completed, B writes item 2→completed. B's write is based on stale data and **reverts item 1 back to pending**.
+
+2. **Truncation race (high):** `save_session()` opens with `"w"` mode which truncates immediately. Concurrent `load_session()` sees an empty file → `JSONDecodeError`.
+
+3. **Session/index inconsistency (high):** No transaction between `save_session()` and `_upsert_index()`. A crash between them leaves the index stale while the session file is updated (or vice versa).
+
+4. **Creation TOCTOU (medium):** `create_session` checks `file.exists()` then writes — two processes can both pass the check.
+
+5. **Index rebuild races (medium):** `list_sessions()` rebuilds `index.json` by scanning all `session_*.json` files. Concurrent writes produce a mixed-time snapshot.
+
+6. **File deletion races (medium):** `trim_sessions()` uses the index to decide what to delete, then deletes files and rebuilds index. Concurrent mutations shift the ground under it.
+
+## All mutation functions are affected
+
+Every function in `src/oboe_mcp/session.py` that calls `save_session()` + `_upsert_index()`:
+
+- `mark_complete`, `mark_skip`, `mark_deferred`, `mark_blocked`, `mark_in_progress`
+- `complete_session`, `cancel_session`, `create_child_session`, `complete_child_session`
+- `merge_items`, `set_approval`, `update_field`
+- `create_session`, `trim_sessions`
+- `_upsert_index` itself (read-modify-write on `index.json`)
+
+## Scope of work
+
+Plan an approach that covers:
+
+1. **Atomic writes** — write to temp file, rename into place (prevents truncation races)
+2. **File locking** — prevent concurrent read-modify-write by distinct processes on the same file(s)
+3. **Transaction-like semantics** — session file + index.json should be consistent
+4. **Backward compatibility** — session file format should not change
+5. **No new runtime dependencies** — prefer `fcntl.flock` (POSIX) with a fallback or no-op on platforms that don't support it
+
+## Key constraints
+
+- Session files live under `{base_dir}/.github/oboe_sessions/` — a plain directory on shared/local filesystem
+- The MCP server uses `mcp.run()` which processes requests sequentially per connection, but multiple connections may exist
+- The CLI (`oboe-cli`) is a short-lived process that reads/writes and exits
+- Both share the same `session.py` business logic — protection belongs there, not in the transport layer
+- `pyproject.toml` dependencies: currently only `mcp>=2.0,<3` — prefer no new library deps
+
+## Design decisions (resolved 2026-07-31 by Dr. Greg)
+
+- **Retry strategy — caller-selectable.** The calling agent chooses between
+  **block** (the default) and **fail-fast** when a lock is already held.
+  Blocking accepts an **optional timeout**; with no timeout supplied it waits
+  indefinitely. Fail-fast raises immediately rather than waiting.
+- **Read path — reads take locks.** `load_session`, `list_sessions`, and the
+  other read entry points acquire a lock rather than reading unsynchronized.
+  A read that feeds a subsequent write holds its lock across the whole
+  read-modify-write cycle.
+
+## Design questions still to resolve
+
+These follow from the two decisions above but were not themselves decided:
+
+- **Lock granularity:** per session file, plus a separate lock for `index.json`
+  (every mutation touches both). Shared vs. exclusive mode for the read path is
+  an open sub-question — `fcntl.flock` offers `LOCK_SH`, which would let
+  concurrent readers proceed without blocking each other.
+- **Lock ordering / deadlock avoidance:** `create_child_session` locks the
+  parent, then creates the child (which locks the child + the index). A single
+  documented acquisition order is required. Not yet chosen.
+- **Timeout default:** whether "block" with no explicit timeout should wait
+  forever or fall back to a generous built-in ceiling.
+- **Mechanism and fallback:** `fcntl.flock` on POSIX; behavior on platforms
+  without it (fallback vs. documented no-op) is undecided.
+
+## File to modify
+
+Primary: `src/oboe_mcp/session.py`
+Possibly: `src/oboe_mcp/server.py` (if transport-layer changes are needed)
+
+## Verification criteria
+
+- Parallel `oboe-cli complete` calls to different items in the same session should not lose updates
+- Parallel `oboe-cli` + MCP server operations on the same session should not corrupt data
+- `index.json` should remain consistent with session files under concurrent load
+- Existing single-process tests should continue to pass

--- a/docs/concurrency-handoff.md
+++ b/docs/concurrency-handoff.md
@@ -71,21 +71,58 @@ Plan an approach that covers:
   A read that feeds a subsequent write holds its lock across the whole
   read-modify-write cycle.
 
-## Design questions still to resolve
+## Remaining questions, as resolved during implementation
 
-These follow from the two decisions above but were not themselves decided:
+- **Lock granularity — one lock per sessions directory.** This *changed* from
+  the per-session-file + separate-index-lock plan. Reading the code showed the
+  per-file split buys nothing: every mutation writes both a session file and
+  the shared `index.json`, so the index lock alone already serializes every
+  writer. Per-file locks would have added a real deadlock hazard (see ordering
+  below) in exchange for concurrency the index lock forecloses anyway. Readers
+  still run in parallel because they take a *shared* lock.
+- **Lock ordering — moot under a single lock.** With one lock per directory,
+  `create_child_session` and `complete_child_session` cannot deadlock against
+  each other; the nested `create_session` / `complete_session` calls re-enter
+  the lock the outer operation already holds. Re-entrancy is per-thread and
+  depth-counted; escalating a held *shared* lock to exclusive is rejected
+  outright, since it would mean releasing mid-operation.
+- **Timeout default — 30s, finite.** An unbounded wait on a lock left by a
+  wedged process gives the caller no diagnostic and no way out. The error
+  names the lock file and the recorded holder. `none` still selects an
+  indefinite wait for callers who want it.
+- **Mechanism and fallback — `fcntl.flock` on POSIX, `O_CREAT | O_EXCL`
+  lockfile elsewhere.** The fallback cannot express shared mode, so readers
+  are serialized there; `supports_shared_locks()` reports which is in use
+  rather than letting callers assume. The fallback reaps a lockfile whose
+  owning PID no longer exists, so a crash cannot wedge a directory forever.
+  No new runtime dependencies were added.
 
-- **Lock granularity:** per session file, plus a separate lock for `index.json`
-  (every mutation touches both). Shared vs. exclusive mode for the read path is
-  an open sub-question — `fcntl.flock` offers `LOCK_SH`, which would let
-  concurrent readers proceed without blocking each other.
-- **Lock ordering / deadlock avoidance:** `create_child_session` locks the
-  parent, then creates the child (which locks the child + the index). A single
-  documented acquisition order is required. Not yet chosen.
-- **Timeout default:** whether "block" with no explicit timeout should wait
-  forever or fall back to a generous built-in ceiling.
-- **Mechanism and fallback:** `fcntl.flock` on POSIX; behavior on platforms
-  without it (fallback vs. documented no-op) is undecided.
+## Implementation notes
+
+- New module `src/oboe_mcp/locking.py` holds both primitives.
+- `session_transaction()` in `session.py` replaces the hand-written
+  load → mutate → `save_session` → `_upsert_index` sequence at every call
+  site. The session file and index row are now written under one held lock,
+  and an exception inside the block aborts the write entirely.
+- The lock file is `.oboe.lock` inside the sessions directory, and is
+  gitignored — session files themselves are tracked in this repo, so ignoring
+  the directory wholesale was not an option.
+- Choosing the policy: `oboe_set_lock_policy` / `oboe_get_lock_policy` (MCP),
+  `--lock-timeout` / `--lock-fail-fast` (CLI), or `OBOE_LOCK_POLICY` /
+  `OBOE_LOCK_TIMEOUT` (environment).
+
+## Verification
+
+`tests/test_concurrency.py` drives real subprocesses, not threads — the
+protection is cross-process, and threads would exercise the re-entrancy path
+instead of the failure being guarded against.
+
+The tests were validated by negative control: with the lock made a no-op and
+the atomic write reverted to a truncating `open(..., "w")`, **10 of the 14
+concurrency tests fail**, including the lost-update, index-consistency, TOCTOU
+and truncation cases. The 4 that still pass under the control are API-semantics
+tests (re-entrancy, escalation, composite operations), which are not intended
+to detect the original bugs.
 
 ## File to modify
 

--- a/src/oboe_mcp/cli.py
+++ b/src/oboe_mcp/cli.py
@@ -21,6 +21,12 @@ from datetime import datetime
 from pathlib import Path
 from typing import Sequence
 
+from oboe_mcp.locking import (
+    DEFAULT_TIMEOUT,
+    LockError,
+    get_default_policy,
+    set_default_policy,
+)
 from oboe_mcp.session import (
     cancel_session,
     complete_child_session,
@@ -234,6 +240,29 @@ def _build_parser() -> argparse.ArgumentParser:
         metavar="DIR",
         default=None,
         help="Project root for .github/oboe_sessions/ (overrides CWD detection)",
+    )
+
+    lock_group = parser.add_argument_group(
+        "concurrency",
+        "Behaviour when another process holds the session lock. "
+        "Defaults may also be set via OBOE_LOCK_POLICY / OBOE_LOCK_TIMEOUT.",
+    )
+    lock_group.add_argument(
+        "--lock-timeout",
+        metavar="SECONDS",
+        default=None,
+        help=(
+            f"Seconds to wait for the session lock "
+            f"(default {DEFAULT_TIMEOUT:g}; 'none' waits indefinitely)"
+        ),
+    )
+    lock_group.add_argument(
+        "--lock-fail-fast",
+        action="store_true",
+        help=(
+            "Fail immediately instead of waiting when the session lock is "
+            "held by another process"
+        ),
     )
 
     sub = parser.add_subparsers(dest="command", metavar="COMMAND")
@@ -892,6 +921,38 @@ _COMMAND_DISPATCH = {
     "trim-sessions":   _cmd_trim_sessions,
 }
 
+def _apply_lock_policy(args: argparse.Namespace) -> None:
+    """Translate the concurrency flags into the process lock policy.
+
+    Flags win over the environment; when neither is given, the policy built
+    from OBOE_LOCK_POLICY / OBOE_LOCK_TIMEOUT is left in place.
+    """
+    current = get_default_policy()
+    blocking = not args.lock_fail_fast if args.lock_fail_fast else current.blocking
+    timeout = current.timeout
+
+    raw = getattr(args, "lock_timeout", None)
+    if raw is not None:
+        cleaned = str(raw).strip().lower()
+        if cleaned in {"none", "never", "infinite", ""}:
+            timeout = None
+        else:
+            try:
+                parsed = float(cleaned)
+            except ValueError:
+                raise ValueError(
+                    f"--lock-timeout must be a number of seconds or 'none', "
+                    f"got {raw!r}"
+                )
+            if parsed <= 0:
+                raise ValueError(
+                    f"--lock-timeout must be greater than zero, got {raw!r}"
+                )
+            timeout = parsed
+
+    set_default_policy(blocking=blocking, timeout=timeout)
+
+
 def main(argv: Sequence[str] | None = None) -> int:
     parser = _build_parser()
     args   = parser.parse_args(argv)
@@ -906,10 +967,19 @@ def main(argv: Sequence[str] | None = None) -> int:
         return 1
 
     try:
+        _apply_lock_policy(args)
+    except ValueError as exc:
+        print(f"❌ {exc}", file=sys.stderr)
+        return 1
+
+    try:
         return handler(args, parser)
     except FileNotFoundError as exc:
         fname = exc.filename or str(exc)
         print(f"❌ Session file not found: {fname}", file=sys.stderr)
+        return 1
+    except LockError as exc:
+        print(f"❌ {exc}", file=sys.stderr)
         return 1
 
 

--- a/src/oboe_mcp/locking.py
+++ b/src/oboe_mcp/locking.py
@@ -1,0 +1,492 @@
+# Copyright (C) 2026 Gregory R. Warnes
+# SPDX-License-Identifier: AGPL-3.0-or-later
+#
+# This file is part of Oboe MCP.
+# For commercial licensing, contact greg@warnes-innovations.com
+
+"""
+Cross-process locking and atomic writes for OBO session storage.
+
+Session state lives in flat JSON files that are mutated by read-modify-write.
+Without protection, two processes (a second VS Code window, the CLI running
+alongside the MCP server, a parallel script) can interleave and silently lose
+updates or read a half-written file.  This module supplies the two primitives
+that prevent that:
+
+* :func:`atomic_write_json` — write to a temp file in the same directory and
+  ``os.replace`` it into position, so a reader never observes a truncated or
+  partially-written file.
+* :func:`sessions_lock` — a cross-process reader/writer lock over a whole
+  sessions directory.
+
+Lock scope
+----------
+The lock covers the **entire sessions directory**, not individual session
+files.  Every mutation writes both a ``session_*.json`` file and the shared
+``index.json``, so an index lock would serialize all writers regardless; a
+per-file lock would add ordering and deadlock hazards while buying no
+additional concurrency.  Readers take a shared lock and so still proceed in
+parallel with one another.
+
+Lock policy
+-----------
+The caller chooses what happens when the lock is already held:
+
+* **block** (default) — wait for the lock, up to an optional timeout.
+  :data:`DEFAULT_TIMEOUT` applies when no timeout is given; pass ``None`` to
+  wait indefinitely.
+* **fail-fast** — raise :class:`LockBusy` immediately.
+
+Set the process default with :func:`set_default_policy`, or override for a
+region of code with the :func:`policy` context manager.
+
+Platform support
+----------------
+POSIX uses ``fcntl.flock``, which supports genuine shared and exclusive modes
+and is released automatically if the process dies.  Elsewhere a portable
+``O_CREAT | O_EXCL`` lockfile fallback is used; it cannot represent shared
+mode, so readers are serialized alongside writers.  The fallback reaps a
+lockfile whose owning process is gone, so a crash does not wedge the
+directory permanently.
+"""
+
+import contextlib
+import errno
+import json
+import os
+import tempfile
+import threading
+import time
+from contextlib import contextmanager
+from dataclasses import dataclass
+from pathlib import Path
+
+try:  # POSIX
+    import fcntl
+    _HAVE_FCNTL = True
+except ImportError:  # pragma: no cover - exercised only on non-POSIX
+    fcntl = None  # type: ignore[assignment]
+    _HAVE_FCNTL = False
+
+
+__all__ = [
+    "DEFAULT_TIMEOUT",
+    "LOCK_FILENAME",
+    "LockBusy",
+    "LockError",
+    "LockPolicy",
+    "LockTimeout",
+    "atomic_write_json",
+    "get_default_policy",
+    "have_real_locking",
+    "policy",
+    "sessions_lock",
+    "set_default_policy",
+    "supports_shared_locks",
+]
+
+
+LOCK_FILENAME = ".oboe.lock"
+"""Name of the lock file created inside a sessions directory."""
+
+DEFAULT_TIMEOUT = 30.0
+"""Seconds a blocking acquire waits before giving up, when none is given.
+
+Deliberately finite.  An unbounded wait on a lock left behind by a wedged
+process gives the caller no diagnostic and no way out; a timeout surfaces the
+problem as an error naming the lock file.
+"""
+
+_POLL_INITIAL = 0.005
+_POLL_MAX = 0.05
+
+
+# ---------------------------------------------------------------------------
+# Errors
+# ---------------------------------------------------------------------------
+
+class LockError(RuntimeError):
+    """Base class for lock acquisition failures."""
+
+
+class LockBusy(LockError):
+    """The lock was held and the caller chose fail-fast."""
+
+
+class LockTimeout(LockError):
+    """The lock was still held when the blocking timeout expired."""
+
+
+# ---------------------------------------------------------------------------
+# Policy
+# ---------------------------------------------------------------------------
+
+@dataclass(frozen=True)
+class LockPolicy:
+    """How to behave when a lock is already held.
+
+    Attributes:
+        blocking: Wait for the lock (True, the default) or raise
+            :class:`LockBusy` immediately (False).
+        timeout: Seconds to wait when *blocking*.  ``None`` waits forever.
+    """
+
+    blocking: bool = True
+    timeout: float | None = DEFAULT_TIMEOUT
+
+    def describe(self) -> str:
+        if not self.blocking:
+            return "fail-fast"
+        if self.timeout is None:
+            return "block (no timeout)"
+        return f"block (timeout {self.timeout:g}s)"
+
+
+def _policy_from_env() -> LockPolicy:
+    """Build the initial default policy from the environment.
+
+    ``OBOE_LOCK_POLICY``  — ``block`` (default) or ``fail-fast``.
+    ``OBOE_LOCK_TIMEOUT`` — seconds, or ``none``/empty to wait forever.
+    """
+    raw_mode = os.environ.get("OBOE_LOCK_POLICY", "").strip().lower()
+    blocking = raw_mode not in {"fail-fast", "fail_fast", "failfast", "nowait"}
+
+    timeout: float | None = DEFAULT_TIMEOUT
+    raw_timeout = os.environ.get("OBOE_LOCK_TIMEOUT")
+    if raw_timeout is not None:
+        cleaned = raw_timeout.strip().lower()
+        if cleaned in {"", "none", "never", "infinite"}:
+            timeout = None
+        else:
+            try:
+                parsed = float(cleaned)
+            except ValueError:
+                parsed = DEFAULT_TIMEOUT
+            timeout = parsed if parsed > 0 else None
+
+    return LockPolicy(blocking=blocking, timeout=timeout)
+
+
+_state = threading.local()
+_default_policy = _policy_from_env()
+
+
+def get_default_policy() -> LockPolicy:
+    """Return the policy used when no scoped override is active."""
+    override = getattr(_state, "policy", None)
+    return override if override is not None else _default_policy
+
+
+def set_default_policy(
+    blocking: bool = True,
+    timeout: float | None = DEFAULT_TIMEOUT,
+) -> LockPolicy:
+    """Set the process-wide default lock policy and return it."""
+    global _default_policy
+    _default_policy = LockPolicy(blocking=blocking, timeout=timeout)
+    return _default_policy
+
+
+@contextmanager
+def policy(
+    blocking: bool = True,
+    timeout: float | None = DEFAULT_TIMEOUT,
+):
+    """Temporarily override the lock policy for the calling thread."""
+    previous = getattr(_state, "policy", None)
+    _state.policy = LockPolicy(blocking=blocking, timeout=timeout)
+    try:
+        yield _state.policy
+    finally:
+        _state.policy = previous
+
+
+def have_real_locking() -> bool:
+    """True when cross-process locking is enforced on this platform."""
+    return True  # fcntl on POSIX, O_EXCL lockfile fallback elsewhere
+
+
+def supports_shared_locks() -> bool:
+    """True when readers can hold the lock concurrently.
+
+    False on the lockfile fallback, where a shared request is satisfied by an
+    exclusive lock and concurrent readers are therefore serialized.
+    """
+    return _HAVE_FCNTL
+
+
+# ---------------------------------------------------------------------------
+# Atomic write
+# ---------------------------------------------------------------------------
+
+def atomic_write_json(path: Path, data: object, indent: int = 2) -> None:
+    """Serialize *data* to *path* atomically.
+
+    The JSON is written to a temporary file in the same directory, flushed and
+    fsynced, then moved into place with :func:`os.replace`.  A concurrent
+    reader sees either the previous file or the new one, never a truncated or
+    partial one.
+    """
+    path = Path(path)
+    path.parent.mkdir(parents=True, exist_ok=True)
+
+    fd, tmp_name = tempfile.mkstemp(
+        dir=str(path.parent),
+        prefix=f".{path.name}.",
+        suffix=".tmp",
+    )
+    tmp_path: str | None = tmp_name
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as handle:
+            json.dump(data, handle, indent=indent)
+            handle.flush()
+            os.fsync(handle.fileno())
+        os.replace(tmp_name, path)
+        tmp_path = None  # ownership transferred to the destination
+    finally:
+        if tmp_path is not None:
+            with contextlib.suppress(OSError):
+                os.unlink(tmp_path)
+
+
+# ---------------------------------------------------------------------------
+# Lock acquisition
+# ---------------------------------------------------------------------------
+
+def _deadline_for(pol: LockPolicy) -> float | None:
+    if not pol.blocking or pol.timeout is None:
+        return None
+    return time.monotonic() + pol.timeout
+
+
+def _busy(lock_path: Path, pol: LockPolicy, waited: float) -> LockError:
+    holder = _describe_holder(lock_path)
+    if pol.blocking:
+        return LockTimeout(
+            f"Timed out after {waited:.1f}s waiting for the OBO session lock "
+            f"at {lock_path}. {holder} If this lock is stale, remove the file. "
+            "Raise the wait with OBOE_LOCK_TIMEOUT."
+        )
+    return LockBusy(
+        f"The OBO session lock at {lock_path} is held by another process and "
+        f"fail-fast was requested. {holder} "
+        "Retry, or use the blocking policy to wait."
+    )
+
+
+def _describe_holder(lock_path: Path) -> str:
+    """Best-effort description of who holds the lock, for error messages."""
+    try:
+        content = lock_path.read_text(encoding="utf-8").strip()
+    except OSError:
+        return ""
+    if not content:
+        return ""
+    return f"Lock file records holder: {content}."
+
+
+def _stamp(lock_path: Path) -> None:
+    """Record the current holder in the lock file, best effort."""
+    with contextlib.suppress(OSError):
+        lock_path.write_text(
+            f"pid={os.getpid()} host={_hostname()} at={time.time():.0f}",
+            encoding="utf-8",
+        )
+
+
+def _hostname() -> str:
+    try:
+        import socket
+
+        return socket.gethostname()
+    except OSError:  # pragma: no cover - hostname is decorative
+        return "unknown"
+
+
+# --- fcntl (POSIX) ---------------------------------------------------------
+
+@contextmanager
+def _flock(lock_path: Path, exclusive: bool, pol: LockPolicy):
+    assert fcntl is not None, "_flock requires POSIX fcntl"
+    mode = fcntl.LOCK_EX if exclusive else fcntl.LOCK_SH
+    deadline = _deadline_for(pol)
+    started = time.monotonic()
+
+    fd = os.open(lock_path, os.O_RDWR | os.O_CREAT, 0o644)
+    try:
+        delay = _POLL_INITIAL
+        while True:
+            try:
+                fcntl.flock(fd, mode | fcntl.LOCK_NB)
+                break
+            except OSError as exc:
+                if exc.errno not in (errno.EACCES, errno.EAGAIN):
+                    raise
+                if not pol.blocking:
+                    raise _busy(lock_path, pol, 0.0) from None
+                if deadline is not None and time.monotonic() >= deadline:
+                    raise _busy(
+                        lock_path, pol, time.monotonic() - started
+                    ) from None
+                time.sleep(delay)
+                delay = min(delay * 2, _POLL_MAX)
+
+        if exclusive:
+            _stamp(lock_path)
+        try:
+            yield
+        finally:
+            with contextlib.suppress(OSError):
+                fcntl.flock(fd, fcntl.LOCK_UN)
+    finally:
+        with contextlib.suppress(OSError):
+            os.close(fd)
+
+
+# --- O_EXCL lockfile fallback (non-POSIX) ----------------------------------
+
+def _holder_pid(lock_path: Path) -> int | None:
+    try:
+        content = lock_path.read_text(encoding="utf-8")
+    except OSError:
+        return None
+    for field in content.split():
+        if field.startswith("pid="):
+            try:
+                return int(field[4:])
+            except ValueError:
+                return None
+    return None
+
+
+def _process_alive(pid: int) -> bool:
+    if pid <= 0:
+        return False
+    try:
+        os.kill(pid, 0)
+    except ProcessLookupError:
+        return False
+    except PermissionError:
+        return True  # exists, owned by someone else
+    except OSError:
+        return True  # cannot tell; assume alive and let the timeout handle it
+    return True
+
+
+def _reap_if_dead(lock_path: Path) -> bool:
+    """Remove a lockfile whose owning process no longer exists."""
+    pid = _holder_pid(lock_path)
+    if pid is None or _process_alive(pid):
+        return False
+    with contextlib.suppress(OSError):
+        os.unlink(lock_path)
+        return True
+    return False
+
+
+@contextmanager
+def _lockfile(lock_path: Path, exclusive: bool, pol: LockPolicy):
+    # The fallback cannot express shared mode; readers take it exclusively.
+    del exclusive
+    deadline = _deadline_for(pol)
+    started = time.monotonic()
+
+    delay = _POLL_INITIAL
+    fd = None
+    while True:
+        try:
+            fd = os.open(lock_path, os.O_CREAT | os.O_EXCL | os.O_RDWR, 0o644)
+            break
+        except FileExistsError:
+            if _reap_if_dead(lock_path):
+                continue
+            if not pol.blocking:
+                raise _busy(lock_path, pol, 0.0) from None
+            if deadline is not None and time.monotonic() >= deadline:
+                raise _busy(lock_path, pol, time.monotonic() - started) from None
+            time.sleep(delay)
+            delay = min(delay * 2, _POLL_MAX)
+
+    try:
+        with contextlib.suppress(OSError):
+            os.write(
+                fd,
+                f"pid={os.getpid()} host={_hostname()} "
+                f"at={time.time():.0f}".encode(),
+            )
+        yield
+    finally:
+        with contextlib.suppress(OSError):
+            os.close(fd)
+        with contextlib.suppress(OSError):
+            os.unlink(lock_path)
+
+
+# --- public entry point ----------------------------------------------------
+
+def _held() -> dict:
+    """Return this thread's map of currently-held locks, keyed by lock path."""
+    held = getattr(_state, "held", None)
+    if held is None:
+        held = {}
+        _state.held = held
+    return held
+
+
+@contextmanager
+def sessions_lock(
+    sessions_dir: Path,
+    exclusive: bool = True,
+    pol: LockPolicy | None = None,
+):
+    """Hold a cross-process lock over *sessions_dir*.
+
+    Args:
+        sessions_dir: The ``.github/oboe_sessions`` directory to lock.
+        exclusive: True for a writer lock, False for a shared reader lock.
+        pol: Policy override; defaults to :func:`get_default_policy`.
+
+    Re-entrant within a thread: a nested acquire of a lock already held is a
+    no-op, so a composite operation can call into a simpler one without
+    self-deadlocking.  Escalating a held shared lock to exclusive is rejected,
+    because releasing and re-acquiring mid-operation would break the atomicity
+    the caller is relying on.
+
+    Raises:
+        LockBusy: fail-fast policy and the lock is held elsewhere.
+        LockTimeout: blocking policy and the timeout expired.
+        ValueError: a nested acquire tried to escalate shared to exclusive.
+    """
+    sessions_dir = Path(sessions_dir)
+    sessions_dir.mkdir(parents=True, exist_ok=True)
+    # Resolve the directory (which now exists) rather than the lock file, so
+    # the re-entrancy key is stable whether or not the lock file is present.
+    lock_path = sessions_dir.resolve() / LOCK_FILENAME
+    key = str(lock_path)
+
+    held = _held()
+    existing = held.get(key)
+    if existing is not None:
+        if exclusive and not existing["exclusive"]:
+            raise ValueError(
+                "Cannot escalate a shared OBO session lock to exclusive while "
+                f"it is held ({lock_path}). Acquire the exclusive lock first."
+            )
+        existing["depth"] += 1
+        try:
+            yield
+        finally:
+            existing["depth"] -= 1
+            if existing["depth"] == 0:
+                held.pop(key, None)
+        return
+
+    effective = pol if pol is not None else get_default_policy()
+    acquire = _flock if _HAVE_FCNTL else _lockfile
+
+    with acquire(lock_path, exclusive, effective):
+        held[key] = {"exclusive": exclusive, "depth": 1}
+        try:
+            yield
+        finally:
+            held.pop(key, None)

--- a/src/oboe_mcp/server.py
+++ b/src/oboe_mcp/server.py
@@ -5,7 +5,7 @@
 # For commercial licensing, contact greg@warnes-innovations.com
 
 """
-Oboe MCP Server — 20 tools for One-By-One session management.
+Oboe MCP Server — 22 tools for One-By-One session management.
 
 Uses MCPServer for concise tool registration.
 """
@@ -21,6 +21,13 @@ from typing import Optional, Sequence
 
 from mcp.server.mcpserver import MCPServer
 
+from oboe_mcp.locking import (
+    DEFAULT_TIMEOUT,
+    LockError,
+    get_default_policy,
+    set_default_policy,
+    supports_shared_locks,
+)
 from oboe_mcp.session import (
     cancel_session,
     complete_child_session,
@@ -49,7 +56,9 @@ from oboe_mcp.session import (
 
 mcp = MCPServer("oboe-mcp", instructions="One-By-One session management tools")
 
-_TOOL_EXCEPTIONS = (OSError, ValueError, json.JSONDecodeError)
+# LockError is included so a contended session surfaces to the calling agent
+# as a normal tool error it can act on, rather than an unhandled exception.
+_TOOL_EXCEPTIONS = (OSError, ValueError, json.JSONDecodeError, LockError)
 
 _REMOTE_SSH_HINT = """\
 
@@ -913,6 +922,76 @@ def oboe_trim_sessions(
         }, indent=2)
     except ValueError as e:
         return f"ERROR: {e}"
+    except _TOOL_EXCEPTIONS as e:
+        return f"ERROR: {e}"
+
+
+# ---------------------------------------------------------------------------
+# Tool: oboe_set_lock_policy
+# ---------------------------------------------------------------------------
+@mcp.tool()
+def oboe_set_lock_policy(
+    blocking: bool = True,
+    timeout_seconds: Optional[float] = DEFAULT_TIMEOUT,
+) -> str:
+    """Choose what happens when another process holds the session lock.
+
+    Session files are shared with the oboe-cli and with any other editor
+    window or agent pointed at the same project, so an operation can find the
+    store locked.  This sets the policy for subsequent tool calls on this
+    server; it does not need to be called at all if the default suits you.
+
+    Args:
+        blocking: True (default) waits for the lock. False fails immediately
+                  with an error when the lock is held, which suits an agent
+                  that would rather retry later than stall.
+        timeout_seconds: How long to wait when blocking. Omit for the default
+                  of 30s. Pass 0 or a negative number to wait indefinitely —
+                  note that a wedged holder will then hang the call with no
+                  diagnostic.
+    """
+    try:
+        timeout: float | None
+        if timeout_seconds is None:
+            timeout = DEFAULT_TIMEOUT
+        elif timeout_seconds <= 0:
+            timeout = None
+        else:
+            timeout = float(timeout_seconds)
+
+        applied = set_default_policy(blocking=blocking, timeout=timeout)
+        return json.dumps({
+            "status": "ok",
+            "action": "lock_policy_set",
+            "blocking": applied.blocking,
+            "timeout_seconds": applied.timeout,
+            "policy": applied.describe(),
+            "concurrent_readers": supports_shared_locks(),
+            "note": (
+                "Applies to subsequent oboe_* calls on this server process. "
+                "Other processes (oboe-cli, another editor window) keep their "
+                "own policy."
+            ),
+        }, indent=2)
+    except _TOOL_EXCEPTIONS as e:
+        return f"ERROR: {e}"
+
+
+# ---------------------------------------------------------------------------
+# Tool: oboe_get_lock_policy
+# ---------------------------------------------------------------------------
+@mcp.tool()
+def oboe_get_lock_policy() -> str:
+    """Report the lock policy currently in effect for this server process."""
+    try:
+        current = get_default_policy()
+        return json.dumps({
+            "status": "ok",
+            "blocking": current.blocking,
+            "timeout_seconds": current.timeout,
+            "policy": current.describe(),
+            "concurrent_readers": supports_shared_locks(),
+        }, indent=2)
     except _TOOL_EXCEPTIONS as e:
         return f"ERROR: {e}"
 

--- a/src/oboe_mcp/session.py
+++ b/src/oboe_mcp/session.py
@@ -14,8 +14,11 @@ relative to {base_dir}/.github/oboe_sessions/.
 
 import json
 import re
+from contextlib import contextmanager
 from datetime import datetime, timezone
 from pathlib import Path
+
+from .locking import atomic_write_json, sessions_lock
 
 # ---------------------------------------------------------------------------
 # Constants
@@ -103,13 +106,66 @@ def resolve_session_file(
 # ---------------------------------------------------------------------------
 
 def load_session(session_file: Path) -> dict:
+    """Read a session file.
+
+    Callers that will subsequently write must hold the exclusive lock across
+    the whole read-modify-write cycle — use :func:`session_transaction` rather
+    than pairing this with :func:`save_session` by hand.  Called on its own it
+    takes a shared lock, so it never observes a partially-written file.
+    """
+    session_file = Path(session_file)
+    with sessions_lock(session_file.parent, exclusive=False):
+        return _load_session_unlocked(session_file)
+
+
+def _load_session_unlocked(session_file: Path) -> dict:
+    """Read a session file assuming the caller already holds the lock."""
     with open(session_file, "r", encoding="utf-8") as f:
         return json.load(f)
 
 
 def save_session(session_file: Path, session: dict) -> None:
-    with open(session_file, "w", encoding="utf-8") as f:
-        json.dump(session, f, indent=2)
+    """Write a session file atomically.
+
+    Kept for callers that manage their own locking; the write itself is atomic
+    either way, so a concurrent reader never sees a truncated file.
+    """
+    session_file = Path(session_file)
+    with sessions_lock(session_file.parent, exclusive=True):
+        atomic_write_json(session_file, session)
+
+
+# ---------------------------------------------------------------------------
+# Transactions
+# ---------------------------------------------------------------------------
+
+@contextmanager
+def session_transaction(session_file: Path):
+    """Hold the sessions-directory lock across a read-modify-write cycle.
+
+    Loads and normalizes the session, yields it for mutation, then writes the
+    session file and updates ``index.json`` — all under one exclusive lock, so
+    the pair cannot be observed or interleaved half-applied.
+
+    The session status is *not* synced automatically; callers that need
+    :func:`_sync_session_status` call it before the block exits, matching the
+    previous hand-written ordering.
+
+    Raises:
+        LockBusy / LockTimeout: per the active lock policy.
+    """
+    session_file = Path(session_file)
+    with sessions_lock(session_file.parent, exclusive=True):
+        session = _load_session_unlocked(session_file)
+        _normalize_existing_items(session)
+        yield session
+        _write_session_and_index(session_file, session)
+
+
+def _write_session_and_index(session_file: Path, session: dict) -> None:
+    """Commit a session plus its index row.  Caller must hold the lock."""
+    atomic_write_json(session_file, session)
+    _upsert_index(session_file.parent, session, session_file.name)
 
 
 # ---------------------------------------------------------------------------
@@ -227,6 +283,12 @@ def _is_valid_index(index: object) -> bool:
 
 
 def load_index(sessions_dir: Path) -> dict:
+    """Read index.json, taking a shared lock unless one is already held."""
+    with sessions_lock(sessions_dir, exclusive=False):
+        return _load_index_unlocked(sessions_dir)
+
+
+def _load_index_unlocked(sessions_dir: Path) -> dict:
     idx_path = _index_path(sessions_dir)
     if idx_path.exists():
         with open(idx_path, encoding="utf-8") as f:
@@ -235,9 +297,9 @@ def load_index(sessions_dir: Path) -> dict:
 
 
 def _save_index(sessions_dir: Path, index: dict) -> None:
+    """Write index.json atomically.  Caller is expected to hold the lock."""
     index["last_updated"] = datetime.now().isoformat()
-    with open(_index_path(sessions_dir), "w", encoding="utf-8") as f:
-        json.dump(index, f, indent=2)
+    atomic_write_json(_index_path(sessions_dir), index)
 
 
 def _pending_count(session: dict) -> int:
@@ -321,11 +383,15 @@ def _sync_session_status(session: dict) -> str:
 
 
 def _rebuild_index_from_files(sessions_dir: Path) -> dict:
-    """Scan all session_*.json files and return a fresh index dict."""
+    """Scan all session_*.json files and return a fresh index dict.
+
+    Caller must hold the sessions lock; the scan reads every session file and
+    would otherwise produce a mixed-time snapshot under concurrent writes.
+    """
     rows = []
     for sf in sorted(sessions_dir.glob("session_*.json")):
         try:
-            s = load_session(sf)
+            s = _load_session_unlocked(sf)
             rows.append({
                 "file": sf.name,
                 "title": s.get("title", sf.stem),
@@ -367,9 +433,12 @@ def _upsert_index(
 
     Automatically repairs a missing, corrupt, or structurally invalid index by
     rebuilding it from the session files on disk before applying the update.
+
+    Caller must hold the exclusive sessions lock — this is a read-modify-write
+    on index.json and is always paired with a session-file write.
     """
     try:
-        index = load_index(sessions_dir)
+        index = _load_index_unlocked(sessions_dir)
         if not _is_valid_index(index):
             raise ValueError("Invalid index structure")
     except (json.JSONDecodeError, ValueError):
@@ -412,36 +481,41 @@ def create_session(
 ) -> dict:
     """Create a new session file and update index.json atomically.
 
+    The existence check and the write happen under one exclusive lock, so two
+    processes cannot both pass the check and race to create the same file.
+
     Raises FileExistsError if the session file already exists.
     """
     validate_session_filename(session_file.name)
 
-    if session_file.exists():
-        raise FileExistsError(f"Session file already exists: {session_file}")
-
     session_file.parent.mkdir(parents=True, exist_ok=True)
 
-    normalized = [
-        _normalize_item(dict(item), idx)
-        for idx, item in enumerate(items, start=1)
-    ]
+    with sessions_lock(session_file.parent, exclusive=True):
+        if session_file.exists():
+            raise FileExistsError(
+                f"Session file already exists: {session_file}"
+            )
 
-    session = {
-        "session_file": session_file.name,
-        "created": datetime.now().isoformat(),
-        "title": title or session_file.stem,
-        "description": description,
-        "status": "active",
-        "parent_session_file": parent_session_file,
-        "parent_item_id": parent_item_id,
-        "child_session_files": [],
-        "active_child_session": None,
-        "items": normalized,
-    }
+        normalized = [
+            _normalize_item(dict(item), idx)
+            for idx, item in enumerate(items, start=1)
+        ]
 
-    _sync_session_status(session)
-    save_session(session_file, session)
-    _upsert_index(session_file.parent, session, session_file.name)
+        session = {
+            "session_file": session_file.name,
+            "created": datetime.now().isoformat(),
+            "title": title or session_file.stem,
+            "description": description,
+            "status": "active",
+            "parent_session_file": parent_session_file,
+            "parent_item_id": parent_item_id,
+            "child_session_files": [],
+            "active_child_session": None,
+            "items": normalized,
+        }
+
+        _sync_session_status(session)
+        _write_session_and_index(session_file, session)
     return session
 
 
@@ -460,20 +534,23 @@ def list_sessions(
     idx_path = _index_path(sessions_dir)
 
     rows = None  # None signals that a rebuild is needed
-    if idx_path.exists():
-        try:
-            index = load_index(sessions_dir)
-            if _is_valid_index(index):
-                rows = index["sessions"]
-        except (json.JSONDecodeError, ValueError):
-            rows = None  # corrupt index – fall through to rebuild
+    with sessions_lock(sessions_dir, exclusive=False):
+        if idx_path.exists():
+            try:
+                index = _load_index_unlocked(sessions_dir)
+                if _is_valid_index(index):
+                    rows = index["sessions"]
+            except (json.JSONDecodeError, ValueError):
+                rows = None  # corrupt index – fall through to rebuild
 
     if rows is None:
-        # Slow path: scan files, rebuild index
-        rebuilt = _rebuild_index_from_files(sessions_dir)
-        rows = rebuilt["sessions"]
-        if rows:
-            _save_index(sessions_dir, rebuilt)
+        # Slow path: scan files and repair the index.  This writes, so it
+        # needs the exclusive lock rather than the reader lock above.
+        with sessions_lock(sessions_dir, exclusive=True):
+            rebuilt = _rebuild_index_from_files(sessions_dir)
+            rows = rebuilt["sessions"]
+            if rows:
+                _save_index(sessions_dir, rebuilt)
 
     # Apply status filter
     if status_filter == "active":
@@ -636,15 +713,12 @@ def mark_complete(
     resolution: str,
 ) -> dict:
     """Mark an item completed with resolution text. Returns updated session."""
-    session = load_session(session_file)
-    _normalize_existing_items(session)
-    item = _require_item(session, item_id)
-    item["status"] = "completed"
-    item["resolution"] = resolution
-    _clear_blocker_fields(item)
-    _sync_session_status(session)
-    save_session(session_file, session)
-    _upsert_index(session_file.parent, session, session_file.name)
+    with session_transaction(session_file) as session:
+        item = _require_item(session, item_id)
+        item["status"] = "completed"
+        item["resolution"] = resolution
+        _clear_blocker_fields(item)
+        _sync_session_status(session)
     return session
 
 
@@ -654,16 +728,13 @@ def mark_skip(
     reason: str = "",
 ) -> dict:
     """Mark an item skipped. Returns updated session."""
-    session = load_session(session_file)
-    _normalize_existing_items(session)
-    item = _require_item(session, item_id)
-    item["status"] = "skipped"
-    if reason:
-        item["skip_reason"] = reason
-    _clear_blocker_fields(item)
-    _sync_session_status(session)
-    save_session(session_file, session)
-    _upsert_index(session_file.parent, session, session_file.name)
+    with session_transaction(session_file) as session:
+        item = _require_item(session, item_id)
+        item["status"] = "skipped"
+        if reason:
+            item["skip_reason"] = reason
+        _clear_blocker_fields(item)
+        _sync_session_status(session)
     return session
 
 
@@ -674,18 +745,15 @@ def mark_deferred(
     deferred_until: str = "",
 ) -> dict:
     """Mark an item deferred. Returns updated item dict."""
-    session = load_session(session_file)
-    _normalize_existing_items(session)
-    item = _require_item(session, item_id)
-    item["status"] = "deferred"
-    if reason:
-        item["defer_reason"] = reason
-    if deferred_until:
-        item["deferred_until"] = deferred_until
-    _clear_blocker_fields(item)
-    _sync_session_status(session)
-    save_session(session_file, session)
-    _upsert_index(session_file.parent, session, session_file.name)
+    with session_transaction(session_file) as session:
+        item = _require_item(session, item_id)
+        item["status"] = "deferred"
+        if reason:
+            item["defer_reason"] = reason
+        if deferred_until:
+            item["deferred_until"] = deferred_until
+        _clear_blocker_fields(item)
+        _sync_session_status(session)
     return item
 
 
@@ -695,45 +763,36 @@ def mark_blocked(
     blocker: str | dict,
 ) -> dict:
     """Mark an item blocked and store blocker metadata."""
-    session = load_session(session_file)
-    _normalize_existing_items(session)
-    item = _require_item(session, item_id)
-    item["status"] = "blocked"
-    item["blocker"] = _blocker_payload(blocker)
-    item["blocked_at"] = datetime.now().isoformat()
-    _sync_session_status(session)
-    save_session(session_file, session)
-    _upsert_index(session_file.parent, session, session_file.name)
+    with session_transaction(session_file) as session:
+        item = _require_item(session, item_id)
+        item["status"] = "blocked"
+        item["blocker"] = _blocker_payload(blocker)
+        item["blocked_at"] = datetime.now().isoformat()
+        _sync_session_status(session)
     return session
 
 
 def mark_in_progress(session_file: Path, item_id: str | int) -> dict:
     """Mark an item in progress. Returns updated session."""
-    session = load_session(session_file)
-    _normalize_existing_items(session)
-    item = _require_item(session, item_id)
-    item["status"] = "in_progress"
-    _clear_blocker_fields(item)
-    _sync_session_status(session)
-    save_session(session_file, session)
-    _upsert_index(session_file.parent, session, session_file.name)
+    with session_transaction(session_file) as session:
+        item = _require_item(session, item_id)
+        item["status"] = "in_progress"
+        _clear_blocker_fields(item)
+        _sync_session_status(session)
     return session
 
 
 def complete_session(session_file: Path) -> dict:
     """Mark the session completed when no actionable items remain."""
-    session = load_session(session_file)
-    _normalize_existing_items(session)
-    if _open_count(session) > 0:
-        raise ValueError(
-            "Cannot complete session while pending, in_progress, "
-            "deferred, or blocked "
-            "items remain"
-        )
-    session["status"] = "completed"
-    session.setdefault("completed_at", datetime.now().isoformat())
-    save_session(session_file, session)
-    _upsert_index(session_file.parent, session, session_file.name)
+    with session_transaction(session_file) as session:
+        if _open_count(session) > 0:
+            raise ValueError(
+                "Cannot complete session while pending, in_progress, "
+                "deferred, or blocked "
+                "items remain"
+            )
+        session["status"] = "completed"
+        session.setdefault("completed_at", datetime.now().isoformat())
     return session
 
 
@@ -743,14 +802,11 @@ def cancel_session(session_file: Path, reason: str = "") -> dict:
     Unlike ``complete_session``, open items are allowed — the session is
     simply marked as no longer being worked.
     """
-    session = load_session(session_file)
-    _normalize_existing_items(session)
-    session["status"] = "cancelled"
-    session["cancelled_at"] = datetime.now().isoformat()
-    if reason:
-        session["cancel_reason"] = reason
-    save_session(session_file, session)
-    _upsert_index(session_file.parent, session, session_file.name)
+    with session_transaction(session_file) as session:
+        session["status"] = "cancelled"
+        session["cancelled_at"] = datetime.now().isoformat()
+        if reason:
+            session["cancel_reason"] = reason
     return session
 
 
@@ -799,44 +855,47 @@ def trim_sessions(
         else:
             cutoff = before
 
-    # Collect all session files from the index (fast path)
-    rows = list_sessions(sessions_dir)
-    deleted: list[str] = []
-    retained: list[str] = []
+    # Deciding what to delete and deleting it must be one atomic step: the
+    # decision is made from the index, and a concurrent mutation between the
+    # two would shift the ground under it.
+    with sessions_lock(sessions_dir, exclusive=True):
+        rows = list_sessions(sessions_dir)
+        deleted: list[str] = []
+        retained: list[str] = []
 
-    for row in rows:
-        filename = row.get("file", "")
-        status   = row.get("status", "")
-        created  = row.get("created", "")  # YYYY-MM-DD or ISO string
+        for row in rows:
+            filename = row.get("file", "")
+            status   = row.get("status", "")
+            created  = row.get("created", "")  # YYYY-MM-DD or ISO string
 
-        # Status filter
-        if status_filter is not None and status != status_filter:
-            retained.append(filename)
-            continue
-
-        # Age filter
-        if cutoff is not None and created:
-            try:
-                created_dt = datetime.fromisoformat(created[:10])  # date portion
-            except ValueError:
-                retained.append(filename)
-                continue
-            if created_dt > cutoff.replace(hour=0, minute=0, second=0, microsecond=0):
+            # Status filter
+            if status_filter is not None and status != status_filter:
                 retained.append(filename)
                 continue
 
-        deleted.append(filename)
+            # Age filter
+            if cutoff is not None and created:
+                try:
+                    created_dt = datetime.fromisoformat(created[:10])  # date portion
+                except ValueError:
+                    retained.append(filename)
+                    continue
+                if created_dt > cutoff.replace(hour=0, minute=0, second=0, microsecond=0):
+                    retained.append(filename)
+                    continue
 
-    if not dry_run:
-        for filename in deleted:
-            sf = sessions_dir / filename
-            try:
-                sf.unlink(missing_ok=True)
-            except OSError:
-                pass
-        # Rebuild index from surviving files
-        rebuilt = _rebuild_index_from_files(sessions_dir)
-        _save_index(sessions_dir, rebuilt)
+            deleted.append(filename)
+
+        if not dry_run:
+            for filename in deleted:
+                sf = sessions_dir / filename
+                try:
+                    sf.unlink(missing_ok=True)
+                except OSError:
+                    pass
+            # Rebuild index from surviving files
+            rebuilt = _rebuild_index_from_files(sessions_dir)
+            _save_index(sessions_dir, rebuilt)
 
     return {
         "deleted":  deleted,
@@ -856,57 +915,60 @@ def create_child_session(
     parent_item_id: str | int | None = None,
 ) -> dict:
     """Create a child session, pause the parent, and optionally block an item.
+
+    Creating the child and pausing the parent happen under a single exclusive
+    lock, so no other process can observe a child that exists while its parent
+    still looks unpaused.  The nested :func:`create_session` re-enters the same
+    lock rather than taking a second one.
     """
-    parent_session = load_session(parent_session_file)
-    _normalize_existing_items(parent_session)
-    if parent_session.get("status") == "completed":
-        raise ValueError(
-            "Cannot create a child session from a completed parent"
+    with sessions_lock(parent_session_file.parent, exclusive=True):
+        parent_session = _load_session_unlocked(parent_session_file)
+        _normalize_existing_items(parent_session)
+        if parent_session.get("status") == "completed":
+            raise ValueError(
+                "Cannot create a child session from a completed parent"
+            )
+        if parent_session.get("active_child_session"):
+            raise ValueError(
+                "Parent session already has an active child session: "
+                f"{parent_session['active_child_session']}"
+            )
+
+        if parent_item_id is not None:
+            _require_item(parent_session, parent_item_id)
+
+        child_session = create_session(
+            child_session_file,
+            items,
+            title=title,
+            description=description,
+            parent_session_file=parent_session_file.name,
+            parent_item_id=parent_item_id,
         )
-    if parent_session.get("active_child_session"):
-        raise ValueError(
-            "Parent session already has an active child session: "
-            f"{parent_session['active_child_session']}"
-        )
 
-    if parent_item_id is not None:
-        _require_item(parent_session, parent_item_id)
+        parent_session.setdefault("child_session_files", [])
+        if child_session_file.name not in parent_session["child_session_files"]:
+            parent_session["child_session_files"].append(
+                child_session_file.name
+            )
+        parent_session["active_child_session"] = child_session_file.name
 
-    child_session = create_session(
-        child_session_file,
-        items,
-        title=title,
-        description=description,
-        parent_session_file=parent_session_file.name,
-        parent_item_id=parent_item_id,
-    )
+        if parent_item_id is not None:
+            parent_item = _require_item(parent_session, parent_item_id)
+            parent_item["status"] = "blocked"
+            parent_item["blocker"] = {
+                "type": "child_session",
+                "session_file": child_session_file.name,
+                "title": child_session.get("title"),
+                "summary": (
+                    "Parent work is blocked until child session "
+                    f"{child_session_file.name} is completed"
+                ),
+            }
+            parent_item["blocked_at"] = datetime.now().isoformat()
 
-    parent_session.setdefault("child_session_files", [])
-    if child_session_file.name not in parent_session["child_session_files"]:
-        parent_session["child_session_files"].append(child_session_file.name)
-    parent_session["active_child_session"] = child_session_file.name
-
-    if parent_item_id is not None:
-        parent_item = _require_item(parent_session, parent_item_id)
-        parent_item["status"] = "blocked"
-        parent_item["blocker"] = {
-            "type": "child_session",
-            "session_file": child_session_file.name,
-            "title": child_session.get("title"),
-            "summary": (
-                "Parent work is blocked until child session "
-                f"{child_session_file.name} is completed"
-            ),
-        }
-        parent_item["blocked_at"] = datetime.now().isoformat()
-
-    _sync_session_status(parent_session)
-    save_session(parent_session_file, parent_session)
-    _upsert_index(
-        parent_session_file.parent,
-        parent_session,
-        parent_session_file.name,
-    )
+        _sync_session_status(parent_session)
+        _write_session_and_index(parent_session_file, parent_session)
 
     return {
         "parent_session": parent_session,
@@ -939,41 +1001,45 @@ def complete_child_session(
             "Must be 'completed' or 'cancelled'."
         )
 
-    if disposition == "completed":
-        child_session = complete_session(child_session_file)
-    else:  # cancelled
-        child_session = cancel_session(child_session_file, reason=resolution)
+    # Closing the child and resuming the parent are one atomic step.  Held
+    # across both, so no other process can see a closed child whose parent is
+    # still paused on it.  The nested complete_session/cancel_session
+    # re-enter this same lock.
+    with sessions_lock(child_session_file.parent, exclusive=True):
+        if disposition == "completed":
+            child_session = complete_session(child_session_file)
+        else:  # cancelled
+            child_session = cancel_session(child_session_file, reason=resolution)
 
-    parent_session_name = child_session.get("parent_session_file")
-    if not parent_session_name:
-        raise ValueError("Session is not a child session")
+        parent_session_name = child_session.get("parent_session_file")
+        if not parent_session_name:
+            raise ValueError("Session is not a child session")
 
-    parent_session_file = child_session_file.parent / parent_session_name
-    parent_session = load_session(parent_session_file)
-    _normalize_existing_items(parent_session)
-    if parent_session.get("active_child_session") == child_session_file.name:
-        parent_session["active_child_session"] = None
+        parent_session_file = child_session_file.parent / parent_session_name
+        parent_session = _load_session_unlocked(parent_session_file)
+        _normalize_existing_items(parent_session)
+        if (
+            parent_session.get("active_child_session")
+            == child_session_file.name
+        ):
+            parent_session["active_child_session"] = None
 
-    parent_item_id = child_session.get("parent_item_id")
-    if parent_item_id is not None:
-        parent_item = _require_item(parent_session, parent_item_id)
-        blocker = parent_item.get("blocker") or {}
-        if blocker.get("session_file") == child_session_file.name:
-            parent_item["status"] = "pending"
-            _clear_blocker_fields(parent_item)
-            note = resolution if resolution else (
-                "Child session was cancelled." if disposition == "cancelled" else ""
-            )
-            if note:
-                parent_item["child_session_resolution"] = note
+        parent_item_id = child_session.get("parent_item_id")
+        if parent_item_id is not None:
+            parent_item = _require_item(parent_session, parent_item_id)
+            blocker = parent_item.get("blocker") or {}
+            if blocker.get("session_file") == child_session_file.name:
+                parent_item["status"] = "pending"
+                _clear_blocker_fields(parent_item)
+                note = resolution if resolution else (
+                    "Child session was cancelled."
+                    if disposition == "cancelled" else ""
+                )
+                if note:
+                    parent_item["child_session_resolution"] = note
 
-    _sync_session_status(parent_session)
-    save_session(parent_session_file, parent_session)
-    _upsert_index(
-        parent_session_file.parent,
-        parent_session,
-        parent_session_file.name,
-    )
+        _sync_session_status(parent_session)
+        _write_session_and_index(parent_session_file, parent_session)
 
     return {
         "child_session": child_session,
@@ -983,32 +1049,31 @@ def complete_child_session(
 
 def merge_items(session_file: Path, items: list[dict]) -> dict:
     """Append items to an existing session and reactivate it if needed."""
-    session = load_session(session_file)
-    _normalize_existing_items(session)
-    existing_ids = {str(item.get("id")) for item in session.get("items", [])}
-    numeric_ids = [
-        int(item_id) for item_id in existing_ids if item_id.isdigit()
-    ]
-    next_idx = max(numeric_ids, default=0) + 1
-    merged_items = []
+    with session_transaction(session_file) as session:
+        existing_ids = {
+            str(item.get("id")) for item in session.get("items", [])
+        }
+        numeric_ids = [
+            int(item_id) for item_id in existing_ids if item_id.isdigit()
+        ]
+        next_idx = max(numeric_ids, default=0) + 1
+        merged_items = []
 
-    for raw_item in items:
-        item = dict(raw_item)
-        if "id" not in item:
-            while str(next_idx) in existing_ids:
+        for raw_item in items:
+            item = dict(raw_item)
+            if "id" not in item:
+                while str(next_idx) in existing_ids:
+                    next_idx += 1
+                item["id"] = next_idx
                 next_idx += 1
-            item["id"] = next_idx
-            next_idx += 1
-        if str(item["id"]) in existing_ids:
-            raise ValueError(f"Duplicate item id: {item['id']}")
-        normalized = _normalize_item(item, item["id"])
-        session.setdefault("items", []).append(normalized)
-        merged_items.append(normalized)
-        existing_ids.add(str(normalized["id"]))
+            if str(item["id"]) in existing_ids:
+                raise ValueError(f"Duplicate item id: {item['id']}")
+            normalized = _normalize_item(item, item["id"])
+            session.setdefault("items", []).append(normalized)
+            merged_items.append(normalized)
+            existing_ids.add(str(normalized["id"]))
 
-    _sync_session_status(session)
-    save_session(session_file, session)
-    _upsert_index(session_file.parent, session, session_file.name)
+        _sync_session_status(session)
     return {
         "session": session,
         "merged_items": merged_items,
@@ -1024,54 +1089,51 @@ def set_approval(
     lifecycle_status: str | None = None,
 ) -> dict:
     """Set approval metadata and optional lifecycle state on an item."""
-    session = load_session(session_file)
-    _normalize_existing_items(session)
-    item = _require_item(session, item_id)
+    with session_transaction(session_file) as session:
+        item = _require_item(session, item_id)
 
-    if approval_mode in {"", "none", "null"}:
-        approval_mode = None
-    if note in {"", "none", "null"}:
-        note = None
-    if lifecycle_status in {"", "none", "null"}:
-        lifecycle_status = None
+        if approval_mode in {"", "none", "null"}:
+            approval_mode = None
+        if note in {"", "none", "null"}:
+            note = None
+        if lifecycle_status in {"", "none", "null"}:
+            lifecycle_status = None
 
-    approval_status = _validate_approval_status(approval_status)
-    approval_mode = _validate_approval_mode(approval_mode)
-    if lifecycle_status is not None:
-        lifecycle_status = _validate_item_status(lifecycle_status)
+        approval_status = _validate_approval_status(approval_status)
+        approval_mode = _validate_approval_mode(approval_mode)
+        if lifecycle_status is not None:
+            lifecycle_status = _validate_item_status(lifecycle_status)
 
-    if approval_status != "approved" and approval_mode is not None:
-        raise ValueError(
-            "approval_mode can only be set when approval_status is "
-            "'approved'"
-        )
+        if approval_status != "approved" and approval_mode is not None:
+            raise ValueError(
+                "approval_mode can only be set when approval_status is "
+                "'approved'"
+            )
 
-    if approval_status == "approved":
-        if approval_mode is None:
-            approval_mode = "immediate"
-        item["approval_status"] = approval_status
-        item["approval_mode"] = approval_mode
-        item["approved_at"] = (
-            item.get("approved_at") or datetime.now().isoformat()
-        )
-    else:
-        item["approval_status"] = approval_status
-        item["approval_mode"] = None
-        item["approved_at"] = None
+        if approval_status == "approved":
+            if approval_mode is None:
+                approval_mode = "immediate"
+            item["approval_status"] = approval_status
+            item["approval_mode"] = approval_mode
+            item["approved_at"] = (
+                item.get("approved_at") or datetime.now().isoformat()
+            )
+        else:
+            item["approval_status"] = approval_status
+            item["approval_mode"] = None
+            item["approved_at"] = None
 
-    item["approval_note"] = note
+        item["approval_note"] = note
 
-    if lifecycle_status is not None:
-        item["status"] = lifecycle_status
-    elif approval_status == "approved" and approval_mode == "delayed":
-        item["status"] = "deferred"
+        if lifecycle_status is not None:
+            item["status"] = lifecycle_status
+        elif approval_status == "approved" and approval_mode == "delayed":
+            item["status"] = "deferred"
 
-    if item["status"] != "blocked":
-        _clear_blocker_fields(item)
+        if item["status"] != "blocked":
+            _clear_blocker_fields(item)
 
-    _sync_session_status(session)
-    save_session(session_file, session)
-    _upsert_index(session_file.parent, session, session_file.name)
+        _sync_session_status(session)
     return item
 
 
@@ -1085,49 +1147,46 @@ def update_field(
 
     Returns the updated item dict.
     """
-    session = load_session(session_file)
-    _normalize_existing_items(session)
-    item = _require_item(session, item_id)
-    new_value: str | int | None = value
-    if field == "status":
-        new_value = _validate_item_status(new_value)
-        if new_value != "blocked":
-            _clear_blocker_fields(item)
-    elif field == "approval_status":
-        new_value = _validate_approval_status(new_value)
-        if new_value == "approved":
-            item["approved_at"] = (
-                item.get("approved_at") or datetime.now().isoformat()
-            )
-        else:
-            item["approval_mode"] = None
-            item["approved_at"] = None
-    elif field == "approval_mode":
-        if new_value in {"", "none", "null"}:
-            new_value = None
-        new_value = _validate_approval_mode(new_value)
-        if new_value is not None:
-            item["approval_status"] = "approved"
-            item["approved_at"] = (
-                item.get("approved_at") or datetime.now().isoformat()
-            )
-    elif field in {
-        "resolution",
-        "skip_reason",
-        "blocked_at",
-        "approved_at",
-        "approval_note",
-    }:
-        if new_value in {"", "none", "null"}:
-            new_value = None
-    if field in _SCORE_COMPONENTS or field == "priority_score":
-        if new_value is None:
-            raise ValueError(f"Field '{field}' cannot be null")
-        new_value = int(new_value)
-    item[field] = new_value
-    if field in _SCORE_COMPONENTS:
-        _recalc_priority(item)
-    _sync_session_status(session)
-    save_session(session_file, session)
-    _upsert_index(session_file.parent, session, session_file.name)
+    with session_transaction(session_file) as session:
+        item = _require_item(session, item_id)
+        new_value: str | int | None = value
+        if field == "status":
+            new_value = _validate_item_status(new_value)
+            if new_value != "blocked":
+                _clear_blocker_fields(item)
+        elif field == "approval_status":
+            new_value = _validate_approval_status(new_value)
+            if new_value == "approved":
+                item["approved_at"] = (
+                    item.get("approved_at") or datetime.now().isoformat()
+                )
+            else:
+                item["approval_mode"] = None
+                item["approved_at"] = None
+        elif field == "approval_mode":
+            if new_value in {"", "none", "null"}:
+                new_value = None
+            new_value = _validate_approval_mode(new_value)
+            if new_value is not None:
+                item["approval_status"] = "approved"
+                item["approved_at"] = (
+                    item.get("approved_at") or datetime.now().isoformat()
+                )
+        elif field in {
+            "resolution",
+            "skip_reason",
+            "blocked_at",
+            "approved_at",
+            "approval_note",
+        }:
+            if new_value in {"", "none", "null"}:
+                new_value = None
+        if field in _SCORE_COMPONENTS or field == "priority_score":
+            if new_value is None:
+                raise ValueError(f"Field '{field}' cannot be null")
+            new_value = int(new_value)
+        item[field] = new_value
+        if field in _SCORE_COMPONENTS:
+            _recalc_priority(item)
+        _sync_session_status(session)
     return item

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -711,10 +711,12 @@ def test_create_child_auto_generates_filename(base_dir, sessions_dir, session_fi
                   "--input-file", str(items_f))
     assert "Child session created" in out
     assert "Parent session paused" in out
-    # A file matching session_YYYYMMDD_HHMMSS.json should now exist
+    # A file matching session_YYYYMMDD_HHMMSS.json should now exist.
+    # Match the session-file glob rather than "every other file in the dir" —
+    # the directory also holds index.json and the .oboe.lock lock file.
     created = [
-        f for f in sessions_dir.iterdir()
-        if f.name != session_file.name and f.name != "index.json"
+        f for f in sessions_dir.glob("session_*.json")
+        if f.name != session_file.name
     ]
     assert len(created) == 1
     assert created[0].name.startswith("session_")

--- a/tests/test_concurrency.py
+++ b/tests/test_concurrency.py
@@ -1,0 +1,546 @@
+# Copyright (C) 2026 Gregory R. Warnes
+# SPDX-License-Identifier: AGPL-3.0-or-later
+#
+# This file is part of Oboe MCP.
+# For commercial licensing, contact greg@warnes-innovations.com
+
+"""
+Concurrency regression tests for OBO session storage.
+
+These use real subprocesses rather than threads: the protection being tested
+is cross-process (fcntl.flock / lockfile), and threads inside one interpreter
+would exercise the re-entrancy path instead of the thing that actually broke.
+
+Verification criteria from docs/concurrency-handoff.md:
+  * parallel completes on different items must not lose updates
+  * parallel operations must not corrupt data
+  * index.json must stay consistent with the session files
+  * existing single-process tests must continue to pass
+"""
+
+import json
+import os
+import subprocess
+import sys
+import threading
+import time
+from pathlib import Path
+
+import pytest
+
+from oboe_mcp.locking import (
+    LockBusy,
+    LockTimeout,
+    atomic_write_json,
+    policy,
+    sessions_lock,
+)
+from oboe_mcp.session import (
+    create_session,
+    list_sessions,
+    load_session,
+    mark_complete,
+    session_status,
+)
+
+REPO_SRC = str(Path(__file__).resolve().parents[1] / "src")
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _sessions_dir(tmp_path: Path) -> Path:
+    d = tmp_path / ".github" / "oboe_sessions"
+    d.mkdir(parents=True, exist_ok=True)
+    return d
+
+
+def _make_session(sessions_dir: Path, n_items: int = 20) -> Path:
+    sf = sessions_dir / "session_20260731_120000.json"
+    create_session(
+        sf,
+        [{"title": f"Item {i}"} for i in range(1, n_items + 1)],
+        title="Concurrency test session",
+    )
+    return sf
+
+
+def _run_workers(script: str, args_per_worker: list[list[str]]) -> list:
+    """Launch one subprocess per arg list, all at once, and collect results."""
+    env = dict(os.environ)
+    env["PYTHONPATH"] = REPO_SRC + os.pathsep + env.get("PYTHONPATH", "")
+
+    procs = [
+        subprocess.Popen(
+            [sys.executable, "-c", script, *args],
+            env=env,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+        )
+        for args in args_per_worker
+    ]
+    results = []
+    for proc in procs:
+        out, err = proc.communicate(timeout=120)
+        results.append((proc.returncode, out.strip(), err.strip()))
+    return results
+
+
+# The worker completes one item.  A barrier on wall-clock start maximizes the
+# chance of a genuine interleave rather than accidental serialization.
+_COMPLETE_WORKER = """
+import sys, time
+from pathlib import Path
+from oboe_mcp.session import mark_complete
+
+session_file, item_id, start_at = sys.argv[1], sys.argv[2], float(sys.argv[3])
+while time.time() < start_at:
+    time.sleep(0.001)
+mark_complete(Path(session_file), item_id, f"done by worker {item_id}")
+print("ok")
+"""
+
+
+# ---------------------------------------------------------------------------
+# Lost updates — the critical risk
+# ---------------------------------------------------------------------------
+
+def test_parallel_completes_do_not_lose_updates(tmp_path):
+    """N processes each complete a different item; all N must survive.
+
+    This is the regression test for the lost-update race: without locking,
+    each process writes a whole session document built from a stale read, so
+    the last writer reverts every other worker's item to pending.
+    """
+    sessions_dir = _sessions_dir(tmp_path)
+    n = 12
+    session_file = _make_session(sessions_dir, n_items=n)
+
+    start_at = time.time() + 1.0
+    results = _run_workers(
+        _COMPLETE_WORKER,
+        [[str(session_file), str(i), str(start_at)] for i in range(1, n + 1)],
+    )
+
+    failures = [r for r in results if r[0] != 0]
+    assert not failures, f"worker(s) failed: {failures}"
+
+    session = load_session(session_file)
+    statuses = {str(i["id"]): i["status"] for i in session["items"]}
+    not_completed = [k for k, v in statuses.items() if v != "completed"]
+    assert not not_completed, (
+        f"{len(not_completed)} of {n} updates were lost: {not_completed}"
+    )
+
+
+def test_index_stays_consistent_with_session_under_parallel_writes(tmp_path):
+    """index.json must agree with the session file after concurrent writes."""
+    sessions_dir = _sessions_dir(tmp_path)
+    n = 10
+    session_file = _make_session(sessions_dir, n_items=n)
+
+    start_at = time.time() + 1.0
+    results = _run_workers(
+        _COMPLETE_WORKER,
+        [[str(session_file), str(i), str(start_at)] for i in range(1, n + 1)],
+    )
+    assert all(r[0] == 0 for r in results)
+
+    stats = session_status(session_file)
+    rows = [
+        r for r in list_sessions(sessions_dir)
+        if r["file"] == session_file.name
+    ]
+    assert len(rows) == 1, "index should hold exactly one row per session"
+    row = rows[0]
+
+    assert stats["open"] == 0
+    assert row["open"] == 0, "index still shows open items after all completed"
+    assert row["pending"] == 0
+    assert row["status"] == "completed"
+    assert row["status"] == stats["status"]
+
+
+def test_index_has_no_duplicate_rows_after_parallel_creates(tmp_path):
+    """Concurrent session creation must not produce duplicate index rows."""
+    sessions_dir = _sessions_dir(tmp_path)
+    script = """
+import sys, time
+from pathlib import Path
+from oboe_mcp.session import create_session
+
+sessions_dir, name, start_at = sys.argv[1], sys.argv[2], float(sys.argv[3])
+while time.time() < start_at:
+    time.sleep(0.001)
+create_session(Path(sessions_dir) / name, [{"title": "x"}], title=name)
+print("ok")
+"""
+    names = [f"session_20260731_1200{i:02d}.json" for i in range(10)]
+    start_at = time.time() + 1.0
+    results = _run_workers(
+        script,
+        [[str(sessions_dir), name, str(start_at)] for name in names],
+    )
+    assert all(r[0] == 0 for r in results), results
+
+    rows = list_sessions(sessions_dir)
+    files = [r["file"] for r in rows]
+    assert len(files) == len(set(files)), f"duplicate index rows: {files}"
+    assert set(files) == set(names), (
+        f"index lost sessions: missing {set(names) - set(files)}"
+    )
+
+
+def test_create_session_toctou_only_one_winner(tmp_path):
+    """Two processes creating the SAME file: exactly one must win."""
+    sessions_dir = _sessions_dir(tmp_path)
+    script = """
+import sys, time
+from pathlib import Path
+from oboe_mcp.session import create_session
+
+sessions_dir, name, start_at = sys.argv[1], sys.argv[2], float(sys.argv[3])
+while time.time() < start_at:
+    time.sleep(0.001)
+try:
+    create_session(Path(sessions_dir) / name, [{"title": "x"}], title=name)
+    print("created")
+except FileExistsError:
+    print("exists")
+"""
+    name = "session_20260731_130000.json"
+    start_at = time.time() + 1.0
+    results = _run_workers(
+        script,
+        [[str(sessions_dir), name, str(start_at)] for _ in range(6)],
+    )
+    assert all(r[0] == 0 for r in results), results
+    outcomes = [r[1] for r in results]
+    assert outcomes.count("created") == 1, (
+        f"expected exactly one winner, got {outcomes}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Truncation race
+# ---------------------------------------------------------------------------
+
+def test_atomic_write_never_exposes_partial_file(tmp_path):
+    """A reader must never observe a truncated or partial document.
+
+    Without atomic writes this fails with JSONDecodeError: the old code opened
+    with mode "w", truncating the file before writing the new content.
+    """
+    target = tmp_path / "big.json"
+    payload: dict[str, object] = {
+        "items": [{"id": i, "text": "x" * 200} for i in range(500)]
+    }
+    atomic_write_json(target, payload)
+
+    errors: list[Exception] = []
+    stop = threading.Event()
+
+    def reader():
+        while not stop.is_set():
+            try:
+                with open(target, encoding="utf-8") as handle:
+                    json.load(handle)
+            except FileNotFoundError:
+                pass  # the rename window is legitimate on some platforms
+            except Exception as exc:  # noqa: BLE001 - recording for assertion
+                errors.append(exc)
+
+    threads = [threading.Thread(target=reader) for _ in range(4)]
+    for t in threads:
+        t.start()
+    try:
+        for i in range(60):
+            payload["revision"] = i
+            atomic_write_json(target, payload)
+    finally:
+        stop.set()
+        for t in threads:
+            t.join(timeout=10)
+
+    assert not errors, f"reader saw a partial file: {errors[:3]}"
+
+
+# ---------------------------------------------------------------------------
+# Lock policy: block / timeout / fail-fast
+# ---------------------------------------------------------------------------
+
+_HOLD_LOCK_WORKER = """
+import sys, time
+from pathlib import Path
+from oboe_mcp.locking import sessions_lock
+
+sessions_dir, hold_for = sys.argv[1], float(sys.argv[2])
+with sessions_lock(Path(sessions_dir), exclusive=True):
+    print("held", flush=True)
+    time.sleep(hold_for)
+"""
+
+
+@pytest.fixture
+def held_lock(tmp_path):
+    """Hold the sessions lock in a separate process for the test's duration."""
+    sessions_dir = _sessions_dir(tmp_path)
+    env = dict(os.environ)
+    env["PYTHONPATH"] = REPO_SRC + os.pathsep + env.get("PYTHONPATH", "")
+    proc = subprocess.Popen(
+        [sys.executable, "-c", _HOLD_LOCK_WORKER, str(sessions_dir), "30"],
+        env=env,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+    )
+    # Wait until the child confirms it actually holds the lock.
+    assert proc.stdout is not None
+    line = proc.stdout.readline().strip()
+    assert line == "held", f"helper failed to take the lock: {line!r}"
+    try:
+        yield sessions_dir
+    finally:
+        proc.kill()
+        proc.wait(timeout=10)
+
+
+def test_fail_fast_raises_immediately_when_lock_is_held(held_lock):
+    started = time.monotonic()
+    with pytest.raises(LockBusy), policy(blocking=False):
+        with sessions_lock(held_lock, exclusive=True):
+            pass
+    assert time.monotonic() - started < 5.0, "fail-fast should not wait"
+
+
+def test_blocking_times_out_when_lock_stays_held(held_lock):
+    started = time.monotonic()
+    with pytest.raises(LockTimeout), policy(blocking=True, timeout=1.0):
+        with sessions_lock(held_lock, exclusive=True):
+            pass
+    waited = time.monotonic() - started
+    assert waited >= 1.0, "should have waited for the timeout"
+    assert waited < 15.0, "should not have waited far beyond the timeout"
+
+
+def test_blocking_acquires_once_the_holder_releases(tmp_path):
+    sessions_dir = _sessions_dir(tmp_path)
+    env = dict(os.environ)
+    env["PYTHONPATH"] = REPO_SRC + os.pathsep + env.get("PYTHONPATH", "")
+    proc = subprocess.Popen(
+        [sys.executable, "-c", _HOLD_LOCK_WORKER, str(sessions_dir), "2"],
+        env=env,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+    )
+    assert proc.stdout is not None
+    assert proc.stdout.readline().strip() == "held"
+
+    try:
+        with policy(blocking=True, timeout=60.0):
+            with sessions_lock(sessions_dir, exclusive=True):
+                acquired = True
+        assert acquired
+    finally:
+        proc.kill()
+        proc.wait(timeout=10)
+
+
+def test_fail_fast_surfaces_through_a_mutation_call(held_lock):
+    """The policy must reach real operations, not just the raw primitive."""
+    session_file = held_lock / "session_20260731_120000.json"
+    # Build the session before the lock is contended is not possible here, so
+    # assert on the failure mode of a mutation against the locked directory.
+    with pytest.raises(LockBusy), policy(blocking=False):
+        mark_complete(session_file, "1", "should not get this far")
+
+
+# ---------------------------------------------------------------------------
+# Re-entrancy and escalation
+# ---------------------------------------------------------------------------
+
+def test_lock_is_reentrant_within_a_process(tmp_path):
+    sessions_dir = _sessions_dir(tmp_path)
+    with sessions_lock(sessions_dir, exclusive=True):
+        with sessions_lock(sessions_dir, exclusive=True):
+            with sessions_lock(sessions_dir, exclusive=False):
+                pass
+    # Released cleanly: a fresh exclusive acquire must still succeed.
+    with policy(blocking=False), sessions_lock(sessions_dir, exclusive=True):
+        pass
+
+
+def test_shared_to_exclusive_escalation_is_rejected(tmp_path):
+    """Escalation would require releasing mid-operation; refuse it loudly."""
+    sessions_dir = _sessions_dir(tmp_path)
+    with sessions_lock(sessions_dir, exclusive=False):
+        with pytest.raises(ValueError, match="escalate"):
+            with sessions_lock(sessions_dir, exclusive=True):
+                pass
+
+
+def test_composite_operation_holds_one_lock_throughout(tmp_path):
+    """create_child_session nests create_session; it must not self-deadlock."""
+    from oboe_mcp.session import complete_child_session, create_child_session
+
+    sessions_dir = _sessions_dir(tmp_path)
+    parent = _make_session(sessions_dir, n_items=3)
+    child = sessions_dir / "session_20260731_120500.json"
+
+    with policy(blocking=True, timeout=10.0):
+        result = create_child_session(
+            parent, child, [{"title": "child work"}],
+            title="Child", parent_item_id=1,
+        )
+    assert result["child_session"]["parent_session_file"] == parent.name
+    assert load_session(parent)["active_child_session"] == child.name
+
+    from oboe_mcp.session import mark_complete as _mc
+
+    _mc(child, "1", "child done")
+    with policy(blocking=True, timeout=10.0):
+        complete_child_session(child, resolution="finished")
+    assert load_session(parent)["active_child_session"] is None
+
+
+# ---------------------------------------------------------------------------
+# Reads take locks
+# ---------------------------------------------------------------------------
+
+def test_readers_do_not_block_each_other(tmp_path):
+    """Shared locks must let concurrent readers proceed together.
+
+    Skipped where the lockfile fallback is in use, which cannot express
+    shared mode.
+    """
+    from oboe_mcp.locking import supports_shared_locks
+
+    if not supports_shared_locks():
+        pytest.skip("platform lacks shared locks; readers are serialized")
+
+    sessions_dir = _sessions_dir(tmp_path)
+    _make_session(sessions_dir, n_items=3)
+
+    with sessions_lock(sessions_dir, exclusive=False):
+        # A second shared acquire from another process must not block.
+        env = dict(os.environ)
+        env["PYTHONPATH"] = REPO_SRC + os.pathsep + env.get("PYTHONPATH", "")
+        script = """
+import sys
+from pathlib import Path
+from oboe_mcp.locking import policy, sessions_lock
+with policy(blocking=True, timeout=5.0):
+    with sessions_lock(Path(sys.argv[1]), exclusive=False):
+        print("ok")
+"""
+        proc = subprocess.run(
+            [sys.executable, "-c", script, str(sessions_dir)],
+            env=env, capture_output=True, text=True, timeout=60,
+            check=False,  # the assertions below inspect returncode themselves
+        )
+        assert proc.returncode == 0, proc.stderr
+        assert proc.stdout.strip() == "ok"
+
+
+# ---------------------------------------------------------------------------
+# Policy reaches the CLI and MCP surfaces
+# ---------------------------------------------------------------------------
+
+def test_cli_fail_fast_flag_reports_the_contended_lock(held_lock, capsys):
+    """oboe-cli --lock-fail-fast must exit non-zero with a clear message."""
+    from oboe_mcp.cli import main
+
+    base_dir = held_lock.parent.parent
+    rc = main([
+        "--base-dir", str(base_dir),
+        "--lock-fail-fast",
+        "sessions",
+    ])
+    assert rc == 1
+    err = capsys.readouterr().err
+    assert "lock" in err.lower()
+
+
+def test_cli_rejects_a_nonsense_lock_timeout(tmp_path, capsys):
+    from oboe_mcp.cli import main
+
+    rc = main([
+        "--base-dir", str(tmp_path),
+        "--lock-timeout", "banana",
+        "sessions",
+    ])
+    assert rc == 1
+    assert "--lock-timeout" in capsys.readouterr().err
+
+
+def test_cli_lock_timeout_none_is_accepted(tmp_path):
+    from oboe_mcp.cli import main
+    from oboe_mcp.locking import get_default_policy, set_default_policy
+
+    saved = get_default_policy()
+    try:
+        rc = main([
+            "--base-dir", str(tmp_path),
+            "--lock-timeout", "none",
+            "sessions",
+        ])
+        assert rc == 0
+        assert get_default_policy().timeout is None
+    finally:
+        set_default_policy(
+            blocking=saved.blocking, timeout=saved.timeout
+        )
+
+
+def test_mcp_tool_reports_lock_contention_as_an_error(held_lock):
+    """A contended lock must reach the agent as a tool error, not a crash."""
+    from oboe_mcp.locking import get_default_policy, set_default_policy
+    from oboe_mcp.server import oboe_list_items, oboe_set_lock_policy
+
+    saved = get_default_policy()
+    try:
+        set_default_policy(blocking=False)
+        payload = json.loads(
+            oboe_set_lock_policy(blocking=False, timeout_seconds=1.0)
+        )
+        assert payload["blocking"] is False
+
+        result = oboe_list_items(
+            session_file="session_20260731_120000.json",
+            base_dir=str(held_lock.parent.parent),
+        )
+        assert result.startswith("ERROR:"), result
+        assert "lock" in result.lower()
+    finally:
+        set_default_policy(blocking=saved.blocking, timeout=saved.timeout)
+
+
+def test_writer_waits_for_reader(tmp_path):
+    """An exclusive acquire must not proceed while a shared lock is held."""
+    sessions_dir = _sessions_dir(tmp_path)
+    _make_session(sessions_dir, n_items=3)
+
+    with sessions_lock(sessions_dir, exclusive=False):
+        env = dict(os.environ)
+        env["PYTHONPATH"] = REPO_SRC + os.pathsep + env.get("PYTHONPATH", "")
+        script = """
+import sys
+from pathlib import Path
+from oboe_mcp.locking import LockError, policy, sessions_lock
+try:
+    with policy(blocking=False):
+        with sessions_lock(Path(sys.argv[1]), exclusive=True):
+            print("acquired")
+except LockError:
+    print("blocked")
+"""
+        proc = subprocess.run(
+            [sys.executable, "-c", script, str(sessions_dir)],
+            env=env, capture_output=True, text=True, timeout=60,
+            check=False,  # the assertions below inspect returncode themselves
+        )
+        assert proc.returncode == 0, proc.stderr
+        assert proc.stdout.strip() == "blocked"


### PR DESCRIPTION
## Summary

Session state was mutated by naive read-modify-write over `session_*.json` plus a separate write to `index.json`, with no locking and no atomic writes. Two processes reaching the same project — the MCP server and `oboe-cli`, a second editor window, a parallel script — could silently lose updates, read a truncated file mid-write, or leave the index disagreeing with the session files.

Analysis and risk inventory: `docs/concurrency-handoff.md` (included in this PR).

## What changed

New module `src/oboe_mcp/locking.py` with two primitives:

- **`atomic_write_json`** — temp file in the same directory, fsync, `os.replace`. A reader now sees either the old document or the new one, never a partial one. `save_session` and `_save_index` both route through it.
- **`sessions_lock`** — cross-process reader/writer lock over the sessions directory. `fcntl.flock` on POSIX; a portable `O_CREAT|O_EXCL` lockfile elsewhere, which reaps a lockfile whose owning PID is gone so a crash cannot wedge the directory. **No new runtime dependencies** — `pyproject.toml` still declares only `mcp>=2.0,<3`.

`session.py` gains `session_transaction()`, replacing the hand-written `load → mutate → save_session → _upsert_index` sequence at every call site. The session file and its index row are written under one held lock, and an exception inside the block aborts the write entirely.

| Risk (from the handoff doc) | Addressed by |
|---|---|
| 1. Lost updates | `session_transaction` holds the exclusive lock across the whole read-modify-write |
| 2. Truncation race | `atomic_write_json` |
| 3. Session/index inconsistency | Both writes under one lock; exception aborts both |
| 4. Creation TOCTOU | `create_session` does its `exists()` check inside the lock |
| 5. Index rebuild races | Rebuild scans under a held lock |
| 6. File deletion races | `trim_sessions` decides and deletes atomically |

Read paths take a **shared** lock, so concurrent readers still run in parallel while never observing a partial write.

## Lock policy is caller-selectable

Default is block, waiting up to 30s, then an error naming the lock file and its recorded holder. Callers who would rather retry than stall can choose fail-fast:

| Surface | Wait longer | Fail immediately |
|---|---|---|
| MCP | `oboe_set_lock_policy(timeout_seconds=120)` | `oboe_set_lock_policy(blocking=false)` |
| CLI | `--lock-timeout 120` | `--lock-fail-fast` |
| Environment | `OBOE_LOCK_TIMEOUT=120` | `OBOE_LOCK_POLICY=fail-fast` |

The 30s default is deliberately finite: an unbounded wait on a lock left by a wedged process gives the caller no diagnostic and no way out. `--lock-timeout none` still selects an indefinite wait for those who want it.

`LockError` was added to the server's `_TOOL_EXCEPTIONS` tuple, which covers all 19 handler sites at once, so contention reaches agents as a normal tool error rather than an unhandled exception. Two new tools (`oboe_set_lock_policy`, `oboe_get_lock_policy`) bring the server to 22; the module docstring count was updated to match.

## Design change worth reviewing

The original plan was a per-session-file lock plus a separate `index.json` lock. **This PR uses one lock per sessions directory instead.** Reading the code showed the split buys nothing: every mutation writes `index.json`, so the index lock already serializes all writers. Per-file locks would have added a real deadlock hazard through `create_child_session` in exchange for concurrency the index lock forecloses anyway. Readers keep their parallelism via the shared lock.

Consequently, lock *ordering* is moot — there is only one lock. `create_child_session` / `complete_child_session` re-enter the lock the outer operation already holds. Re-entrancy is per-thread and depth-counted; escalating a held shared lock to exclusive raises rather than silently releasing mid-operation.

## Testing

`tests/test_concurrency.py` drives **real subprocesses**, not threads — the protection is cross-process, and threads would exercise the re-entrancy path instead of the failure being guarded against.

**Validated by negative control.** With the lock made a no-op and the atomic write reverted to a truncating `open(..., "w")`, **10 of the 14 core concurrency tests fail** — covering lost updates, index consistency, creation TOCTOU and truncation, the last surfacing as exactly the `JSONDecodeError` described as risk 2. The 4 that still pass under the control are API-semantics tests (re-entrancy, escalation, composite operations), which are not intended to detect the original bugs.

**281 tests pass.** The 263 pre-existing tests are unchanged except for one over-broad assertion in `test_cli.py` that counted every file in the sessions directory and now matches the `session_*.json` glob instead — the lock file legitimately lives in that directory.

## Notes for the reviewer

- The lock file is `.oboe.lock` inside the sessions directory, now gitignored. Session files themselves are tracked in this repo, so ignoring the directory wholesale was not an option.
- **The non-POSIX lockfile fallback is untested on real Windows** — no runner available. The POSIX path is what CI and local runs exercise. The code reports `concurrent_readers: false` there rather than implying a guarantee it cannot make.
- `SKILL.md` is not updated because this repo has none; the agent-facing skill lives in `agent-config` and is a separate change.
- Backward compatible: the session file format is unchanged.
