### PR TITLE
docs(release): codify artifact verification, scope the TestPyPI dry run

### DIFF
--- a/.github/instructions/release-workflow.instructions.md
+++ b/.github/instructions/release-workflow.instructions.md
@@ -5,10 +5,87 @@ name: "Oboe Release Workflow"
 # Oboe MCP Release Workflow
 
 - Treat release work in this repository as a staged workflow: inspect repo state, run tests, complete release-prep edits, validate packaging, then handle remote release steps.
-- Prefer the verified test command `.venv/bin/python -m pytest tests/test_session.py tests/test_server.py` unless the user requests a different scope.
+- Run the **whole** suite: `uv run pytest tests/ -q`. Do not run a named subset — this instruction used to name `tests/test_session.py tests/test_server.py`, which silently skipped `test_cli.py`, `test_concurrency.py`, and `test_migrate.py` as those were added.
 - Keep release edits minimal and targeted. Do not revert unrelated dirty-worktree files unless the user explicitly asks.
 - Before any irreversible action, pause for confirmation even if the user's initial request already said to publish.
 - The required confirmation boundary includes each of these actions: `git push`, tag creation, GitHub release creation, and PyPI publication.
 - When asking for confirmation, summarize the exact action, the version, and the branch or tag involved.
 - After a live publish, verify the result end to end: release workflow status, PyPI visibility, and at least one package resolution or install check.
 - If clarification, triage, or blocker handling is needed, prefer creating or resuming an OBO session rather than handling it as an unstructured side conversation.
+
+## Version sources must move together
+
+Two files carry the version, and they have drifted before:
+
+- `pyproject.toml` → `version`
+- `src/oboe_mcp/__init__.py` → `__version__`
+
+Update both in the same commit and confirm they agree before building. The 0.2.0
+release shipped reporting `__version__ == "0.1.2"` because only the first was
+bumped; nothing failed, and nobody noticed until 0.3.0.
+
+## Verifying the artifact — always
+
+Before tagging, build and exercise the real artifact. `oboe-mcp` is pure Python
+with no compiled extensions, so a local build is equivalent to the one CI
+produces, and this catches artifact-level defects while the version number is
+still unspent:
+
+```bash
+uv build --out-dir dist/
+uv run --isolated --no-project \
+  --with ./dist/oboe_mcp-<VERSION>-py3-none-any.whl --with 'mcp<3.0' \
+  oboe-mcp --help
+```
+
+Smoke-test every declared entry point (`oboe-mcp`, `oboe-cli`) **and any command
+the release notes tell users to run**. That last part is not optional: the 0.3.0
+changelog advertised `uvx oboe-mcp migrate`, a command that did not exist, whose
+fallback script shipped in neither the sdist nor the wheel. Running the
+advertised command against a clean install is what catches that class of defect.
+
+A PyPI version number is immutable and cannot be reused. A broken `X.Y.Z` means
+shipping `X.Y.Z+1`, not replacing it.
+
+## TestPyPI dry run — only when `publish.yml` changed
+
+Dispatch the workflow against TestPyPI **when, and only when,
+`.github/workflows/publish.yml` has been modified since the last release**:
+
+```bash
+gh workflow run publish.yml --ref main -f repository=testpypi
+```
+
+**What it is for:** exercising the CI publish path end to end — the build job,
+the artifact hand-off between jobs, action pins, permissions. That is the only
+thing it uniquely validates.
+
+**What it does NOT do. Do not treat a result either way as evidence about PyPI:**
+
+- **It does not validate PyPI's trusted publisher configuration.** TestPyPI
+  requires a wholly separate registration. On 2026-07-31 a dry run failed with
+  `invalid-publisher` while PyPI's own configuration was intact, and the real
+  publish then succeeded with the workflow unchanged. A pass would have been
+  equally uninformative.
+- **It does not catch packaging or metadata errors** beyond what `twine check`
+  in the build job and a local `uv build` already surface.
+- **Installing from TestPyPI is not a faithful test.** Dependencies such as
+  `mcp` are generally absent there, so the install needs `--extra-index-url`
+  back to real PyPI, producing a hybrid resolution no real user experiences.
+
+Running it on every release regardless would spend real time on a step that
+usually reports nothing — and a check that habitually says nothing is one people
+learn to skip at exactly the moment it would have mattered.
+
+Trusted publisher registrations (both indexes) use:
+
+```
+Owner:              Warnes-Innovations
+Repository:         oboe-mcp
+Workflow filename:  publish.yml
+Environment:        (blank)
+```
+
+Registration is manual on pypi.org / test.pypi.org and cannot be automated from
+a checkout. Because `publish.yml` declares no `environment:`, the OIDC claim is
+`MISSING`; a publisher registered *with* an environment name would not match.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -122,8 +122,47 @@ was already requested in general terms:
 - GitHub release creation
 - PyPI publication
 
-Version numbers follow semantic versioning and are set in `pyproject.toml`.
-Update `CHANGELOG.md` in the same change as the version bump.
+Version numbers follow semantic versioning. **Two files carry the version and
+must be updated together** — `pyproject.toml` (`version`) and
+`src/oboe_mcp/__init__.py` (`__version__`). They have drifted before: 0.2.0
+shipped reporting `__version__ == "0.1.2"`. Update `CHANGELOG.md` in the same
+change as the bump.
+
+### Verify the artifact before tagging — always
+
+A PyPI version number is immutable and cannot be reused; a broken `X.Y.Z` means
+shipping `X.Y.Z+1`. Build and exercise the real artifact first:
+
+```bash
+uv build --out-dir dist/
+uv run --isolated --no-project \
+  --with ./dist/oboe_mcp-<VERSION>-py3-none-any.whl --with 'mcp<3.0' \
+  oboe-mcp --help
+```
+
+Smoke-test both entry points (`oboe-mcp`, `oboe-cli`) **and any command the
+release notes tell users to run**. The 0.3.0 changelog advertised
+`uvx oboe-mcp migrate` while no such command existed — running the advertised
+command against a clean install is what catches that.
+
+### TestPyPI dry run — only when `publish.yml` changed
+
+```bash
+gh workflow run publish.yml --ref main -f repository=testpypi
+```
+
+Run this **only when `.github/workflows/publish.yml` has changed since the last
+release**. It validates the CI publish path — build job, artifact hand-off,
+action pins, permissions — and nothing else.
+
+It specifically does **not** validate PyPI's trusted publisher configuration:
+TestPyPI needs a separate registration, and a failure there says nothing about
+PyPI. On 2026-07-31 a dry run failed with `invalid-publisher` while PyPI's
+config was intact and the real publish succeeded unchanged.
+
+Running it every time would spend real effort on a step that usually reports
+nothing — and a check that habitually says nothing is one people learn to skip
+at exactly the moment it would have mattered.
 
 ## Reporting a security issue
 


### PR DESCRIPTION
## Summary

Codifies three release rules that were previously unwritten or actively wrong. Documentation only — no code changes.

## 1. Run the full test suite, not a named subset

`release-workflow.instructions.md` said to prefer:

```
.venv/bin/python -m pytest tests/test_session.py tests/test_server.py
```

That subset runs **166 of 316 tests**. It silently skipped `test_cli.py`, `test_concurrency.py` and `test_migrate.py` as each was added — 47% of the suite, including *every* concurrency and migration test. A release gate that quietly stops covering new work is worse than no gate, because it still reports green.

Now: `uv run pytest tests/ -q`, with a note explaining why a named subset is not acceptable.

## 2. Version sources must move together

`pyproject.toml` and `src/oboe_mcp/__init__.py` both carry the version, and they drifted: **0.2.0 shipped reporting `__version__ == "0.1.2"`** because only the first was bumped. Nothing failed, so nothing surfaced it until 0.3.0.

## 3. Verify the artifact before tagging — always

Build the wheel, install it into an isolated environment, and smoke-test both entry points **and any command the release notes tell users to run**.

That last clause is the load-bearing one. The 0.3.0 changelog advertised `uvx oboe-mcp migrate` while no such command existed, and its fallback shell script shipped in neither the sdist nor the wheel. Running the *advertised* command against a clean install is what catches that class of defect — testing only `--help` would not have.

## 4. TestPyPI dry run — scoped, not unconditional

Run it **only when `.github/workflows/publish.yml` has changed since the last release**.

It validates the CI publish path — build job, artifact hand-off between jobs, action pins, permissions. That is the only thing it uniquely validates. It specifically does **not**:

- **Validate PyPI's trusted publisher config.** TestPyPI needs a separate registration. On 2026-07-31 a dry run failed `invalid-publisher` while PyPI's config was intact, and the real publish then succeeded with the workflow unchanged. A pass would have been equally uninformative.
- **Catch metadata errors** beyond what `twine check` and a local `uv build` already surface.
- **Support a faithful install test** — dependencies like `mcp` are generally absent from TestPyPI, so installing needs `--extra-index-url` back to real PyPI, producing a hybrid resolution no user experiences.

An earlier version of this proposal made the dry run an unconditional first step for every release. That was too strong, and scoping it is the point of this PR: a check that usually reports nothing is one people learn to skip at exactly the moment it would have mattered.

Also records the trusted publisher registration values for both indexes, and that no `environment:` is declared — so the OIDC claim is `MISSING`, and a publisher registered *with* an environment name would not match.

## Testing

316 tests pass; `codespell` clean; confidential scan clean. Documentation-only change.
