### PR TITLE
chore(docs): promote release-process and branch-policy docs to main

### DIFF
--- a/.github/instructions/release-workflow.instructions.md
+++ b/.github/instructions/release-workflow.instructions.md
@@ -5,10 +5,87 @@ name: "Oboe Release Workflow"
 # Oboe MCP Release Workflow
 
 - Treat release work in this repository as a staged workflow: inspect repo state, run tests, complete release-prep edits, validate packaging, then handle remote release steps.
-- Prefer the verified test command `.venv/bin/python -m pytest tests/test_session.py tests/test_server.py` unless the user requests a different scope.
+- Run the **whole** suite: `uv run pytest tests/ -q`. Do not run a named subset — this instruction used to name `tests/test_session.py tests/test_server.py`, which silently skipped `test_cli.py`, `test_concurrency.py`, and `test_migrate.py` as those were added.
 - Keep release edits minimal and targeted. Do not revert unrelated dirty-worktree files unless the user explicitly asks.
 - Before any irreversible action, pause for confirmation even if the user's initial request already said to publish.
 - The required confirmation boundary includes each of these actions: `git push`, tag creation, GitHub release creation, and PyPI publication.
 - When asking for confirmation, summarize the exact action, the version, and the branch or tag involved.
 - After a live publish, verify the result end to end: release workflow status, PyPI visibility, and at least one package resolution or install check.
 - If clarification, triage, or blocker handling is needed, prefer creating or resuming an OBO session rather than handling it as an unstructured side conversation.
+
+## Version sources must move together
+
+Two files carry the version, and they have drifted before:
+
+- `pyproject.toml` → `version`
+- `src/oboe_mcp/__init__.py` → `__version__`
+
+Update both in the same commit and confirm they agree before building. The 0.2.0
+release shipped reporting `__version__ == "0.1.2"` because only the first was
+bumped; nothing failed, and nobody noticed until 0.3.0.
+
+## Verifying the artifact — always
+
+Before tagging, build and exercise the real artifact. `oboe-mcp` is pure Python
+with no compiled extensions, so a local build is equivalent to the one CI
+produces, and this catches artifact-level defects while the version number is
+still unspent:
+
+```bash
+uv build --out-dir dist/
+uv run --isolated --no-project \
+  --with ./dist/oboe_mcp-<VERSION>-py3-none-any.whl --with 'mcp<3.0' \
+  oboe-mcp --help
+```
+
+Smoke-test every declared entry point (`oboe-mcp`, `oboe-cli`) **and any command
+the release notes tell users to run**. That last part is not optional: the 0.3.0
+changelog advertised `uvx oboe-mcp migrate`, a command that did not exist, whose
+fallback script shipped in neither the sdist nor the wheel. Running the
+advertised command against a clean install is what catches that class of defect.
+
+A PyPI version number is immutable and cannot be reused. A broken `X.Y.Z` means
+shipping `X.Y.Z+1`, not replacing it.
+
+## TestPyPI dry run — only when `publish.yml` changed
+
+Dispatch the workflow against TestPyPI **when, and only when,
+`.github/workflows/publish.yml` has been modified since the last release**:
+
+```bash
+gh workflow run publish.yml --ref main -f repository=testpypi
+```
+
+**What it is for:** exercising the CI publish path end to end — the build job,
+the artifact hand-off between jobs, action pins, permissions. That is the only
+thing it uniquely validates.
+
+**What it does NOT do. Do not treat a result either way as evidence about PyPI:**
+
+- **It does not validate PyPI's trusted publisher configuration.** TestPyPI
+  requires a wholly separate registration. On 2026-07-31 a dry run failed with
+  `invalid-publisher` while PyPI's own configuration was intact, and the real
+  publish then succeeded with the workflow unchanged. A pass would have been
+  equally uninformative.
+- **It does not catch packaging or metadata errors** beyond what `twine check`
+  in the build job and a local `uv build` already surface.
+- **Installing from TestPyPI is not a faithful test.** Dependencies such as
+  `mcp` are generally absent there, so the install needs `--extra-index-url`
+  back to real PyPI, producing a hybrid resolution no real user experiences.
+
+Running it on every release regardless would spend real time on a step that
+usually reports nothing — and a check that habitually says nothing is one people
+learn to skip at exactly the moment it would have mattered.
+
+Trusted publisher registrations (both indexes) use:
+
+```
+Owner:              Warnes-Innovations
+Repository:         oboe-mcp
+Workflow filename:  publish.yml
+Environment:        (blank)
+```
+
+Registration is manual on pypi.org / test.pypi.org and cannot be automated from
+a checkout. Because `publish.yml` declares no `environment:`, the OIDC claim is
+`MISSING`; a publisher registered *with* an environment name would not match.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -122,8 +122,47 @@ was already requested in general terms:
 - GitHub release creation
 - PyPI publication
 
-Version numbers follow semantic versioning and are set in `pyproject.toml`.
-Update `CHANGELOG.md` in the same change as the version bump.
+Version numbers follow semantic versioning. **Two files carry the version and
+must be updated together** — `pyproject.toml` (`version`) and
+`src/oboe_mcp/__init__.py` (`__version__`). They have drifted before: 0.2.0
+shipped reporting `__version__ == "0.1.2"`. Update `CHANGELOG.md` in the same
+change as the bump.
+
+### Verify the artifact before tagging — always
+
+A PyPI version number is immutable and cannot be reused; a broken `X.Y.Z` means
+shipping `X.Y.Z+1`. Build and exercise the real artifact first:
+
+```bash
+uv build --out-dir dist/
+uv run --isolated --no-project \
+  --with ./dist/oboe_mcp-<VERSION>-py3-none-any.whl --with 'mcp<3.0' \
+  oboe-mcp --help
+```
+
+Smoke-test both entry points (`oboe-mcp`, `oboe-cli`) **and any command the
+release notes tell users to run**. The 0.3.0 changelog advertised
+`uvx oboe-mcp migrate` while no such command existed — running the advertised
+command against a clean install is what catches that.
+
+### TestPyPI dry run — only when `publish.yml` changed
+
+```bash
+gh workflow run publish.yml --ref main -f repository=testpypi
+```
+
+Run this **only when `.github/workflows/publish.yml` has changed since the last
+release**. It validates the CI publish path — build job, artifact hand-off,
+action pins, permissions — and nothing else.
+
+It specifically does **not** validate PyPI's trusted publisher configuration:
+TestPyPI needs a separate registration, and a failure there says nothing about
+PyPI. On 2026-07-31 a dry run failed with `invalid-publisher` while PyPI's
+config was intact and the real publish succeeded unchanged.
+
+Running it every time would spend real effort on a step that usually reports
+nothing — and a check that habitually says nothing is one people learn to skip
+at exactly the moment it would have mattered.
 
 ## Reporting a security issue
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -27,6 +27,21 @@ feature branch ──PR──> devel ──PR──> main ──> PyPI release
   `docs/…`.
 - Promotion from `devel` to `main` is its own pull request, made when the work
   on `devel` is ready to be released.
+- **Merge `main` back into `devel` immediately after each promotion.** The
+  promotion PR adds a merge commit to `main` that `devel` never receives, so
+  without this the two branches read as diverged even when their content is
+  byte-identical:
+
+  ```bash
+  git fetch origin
+  git push origin origin/main:devel      # fast-forward; devel has no unique commits
+  ```
+
+  Skipping it is not harmless. The delta accumulates, and "is `main` current?"
+  stops being answerable from ancestry — you have to diff the trees instead.
+  That ambiguity is what let `main` silently drift five commits ahead of the
+  default branch earlier, which in turn is why a feature branch was cut from
+  the wrong base.
 - Publishing to PyPI happens from `main` after that promotion. It is a
   separate, deliberately gated step — see *Releases* below.
 


### PR DESCRIPTION
## Promotion: `devel` → `main` (documentation only)

Lands the release-process and branch-policy documentation from #17 and #18.

**No code changes, no version bump.** `pyproject.toml` stays at `0.3.0`, already published — nothing here needs a release.

| File | Change |
|---|---|
| `.github/instructions/release-workflow.instructions.md` | +81 |
| `CONTRIBUTING.md` | +58 |

### What lands

**From #17 — release process:**

- **Run the full test suite, not a named subset.** The instruction file named `tests/test_session.py tests/test_server.py`, measured at **166 of 316 tests** — silently skipping `test_cli.py`, `test_concurrency.py` and `test_migrate.py` as each was added. That is 47% of the suite, and every concurrency and migration test.
- **Version sources must move together** — `pyproject.toml` and `src/oboe_mcp/__init__.py` drifted once already, and 0.2.0 shipped reporting `__version__ == "0.1.2"`.
- **Verify the artifact before tagging — always.** Build, install into an isolated environment, and smoke-test both entry points *and any command the release notes tell users to run*. Testing only `--help` would not have caught the advertised-but-nonexistent `uvx oboe-mcp migrate`.
- **TestPyPI dry run — only when `publish.yml` changed.** Scoped deliberately: it validates the CI publish path and nothing else, and specifically does not validate PyPI's trusted publisher configuration.

**From #18 — branch policy:**

- **Merge `main` back into `devel` immediately after each promotion**, as a fast-forward push. Without it the branches read as diverged even when byte-identical, and "is `main` current?" stops being answerable from ancestry.

### After this merges

The back-merge will be run immediately, exercising the new rule on the promotion that introduced it.
