### PR TITLE
fix: validate caller input at every boundary (#20)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,16 +26,25 @@ The format is based on Keep a Changelog and this project uses Semantic Versionin
   `unsupported operand type(s) for +: 'int' and 'str'` — naming neither the
   offending item nor the offending field.
 
-  **Validation at the input boundary.** `validate_score_components()` runs on
-  every caller-supplied item before anything is written, and rejects a bad
-  value with `item 'example': 'dependencies' must be a number 0-5 (got str:
-  '...')`. Applied in `create_session`, `merge_items`, `create_child_session`
-  and `update_field` — i.e. `oboe_create`, `oboe_merge_items`,
-  `oboe_create_child_session` and `oboe_update_field`. Validation happens
-  *before* the transaction opens, so a rejected batch writes nothing and
-  appends nothing. As a second layer, the arithmetic itself now checks each
-  component's type, so no route into it — including an old session file — can
-  produce a bare `TypeError`.
+  Two independent layers now close it:
+
+  - **Validation at the input boundary.** `validate_score_components()` runs
+    on every caller-supplied item before anything is written, and rejects a
+    bad value with `item 'example': 'dependencies' must be a number 0-5 (got
+    str: '...')`. Applied in `create_session`, `merge_items`,
+    `create_child_session` and `update_field` — i.e. `oboe_create`,
+    `oboe_merge_items`, `oboe_create_child_session` and `oboe_update_field`.
+    Validation happens *before* the transaction opens, so a rejected batch
+    writes nothing and appends nothing. As a second layer, the arithmetic
+    itself now checks each component's type, so no route into it — including
+    an old session file — can produce a bare `TypeError`.
+  - **The contract is documented.** The `items` JSON schema published by
+    `oboe_create`, `oboe_merge_items` and `oboe_create_child_session` now
+    types the four factors as `number` with `minimum: 0` / `maximum: 5`, and
+    states that `dependencies` is dependency *pressure* as a number rather
+    than a description of what the item depends on — the misreading its name
+    invites. The tool descriptions, `docs/SESSION_FORMAT.md`, and the
+    `/obo` workflow prompt say the same.
 
   Booleans, containers, `null`, fractional floats and — at the JSON tools —
   numeric strings are all rejected rather than coerced. `oboe_update_field`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -71,6 +71,15 @@ The format is based on Keep a Changelog and this project uses Semantic Versionin
   instead of what was selected (a row with no `file` was previously counted as
   a deletion that never happened).
 
+- **`complete_child_session` could wedge a parent session permanently.** It
+  called `.get` on `blocker` without checking it was still a dict, and
+  `oboe_update_field` documents itself as setting *any* field. After
+  `blocker` had been set to a string, completing the child raised
+  `AttributeError` — but only after the child had already been written
+  completed, leaving the parent `paused` with a dangling
+  `active_child_session` that no tool could clear. Retrying failed the same
+  way. The shape is now checked.
+
 - **`oboe_create` accepted duplicate item ids; `oboe_merge_items` rejected
   them.** A second item sharing an id is unreachable — every lookup resolves
   to the first — so it could never be completed or skipped and the session
@@ -86,11 +95,54 @@ The format is based on Keep a Changelog and this project uses Semantic Versionin
   name is checked against the documented item schema instead of being written
   through.
 
+- **A structurally-valid `index.json` with unusable rows crashed every write.**
+  `_is_valid_index` checked only the top level, so `{"sessions": ["oops"]}`
+  passed and `_upsert_index` then raised `TypeError: string indices must be
+  integers` — *after* `atomic_write_json` had already written the session
+  file, leaving session and index out of step on every mutating call.
+  `list_sessions` handed the same rows back to callers, which failed on
+  `.get`. Row shape is now part of validity, so both route through the
+  rebuild-from-disk repair this index already had. `reindex` carried a comment
+  about exactly this hazard; its neighbours never got the guard.
+
 - **`oboe_trim_sessions` crashed on a timezone-aware `before`.** `created` is
   parsed from a bare `YYYY-MM-DD` and is naive, so an ISO-8601 string with an
   offset — the likeliest form for a machine to emit — raised
   `TypeError: can't compare offset-naive and offset-aware datetimes` from
   inside a delete operation. An aware cutoff is now converted to local naive.
+
+- **A malformed session file was diagnosed in the interpreter's vocabulary.**
+  `json.load` guarantees valid JSON, not a valid session, and these files are
+  hand-editable and synced between machines. `"items": "oops"` produced
+  `dictionary update sequence element #0 has length 1`, `"items": [null]`
+  produced `'NoneType' object is not iterable`, and a top-level list produced
+  `'list' object has no attribute 'get'` — none naming the file. Loading now
+  checks the container shape and reports e.g. `Malformed session file
+  session_20260411_120000.json: item #1 must be an object, got NoneType`. The
+  same check applies to the `items` argument on the way in. Field-level rules
+  stay where they were, so a file whose *values* predate a constraint still
+  loads.
+
+  This also closed a latent crash: `child_session_files` was never checked to
+  be a list, and `create_child_session` appends to it.
+
+- **Eight `oboe-cli` commands printed a traceback instead of an error.**
+  `main()` caught only `FileNotFoundError` and `LockError`, so `status`,
+  `list`, `show` and five others surfaced a raw `ValueError`/`KeyError` — a
+  merely malformed session file produced a traceback. `main()` now reports
+  those as `❌ <message>` with exit 1. Deliberately not a blanket
+  `except Exception`: unlike an MCP client, a CLI user is served by a
+  traceback when something is genuinely a defect.
+
+- **Unhandled exceptions reached the MCP client raw.** `_TOOL_EXCEPTIONS`
+  covered `OSError`, `ValueError`, `JSONDecodeError` and `LockError`; 14 of
+  the 23 tools did not catch even `KeyError`, and nothing caught `TypeError`
+  or `AttributeError` — which is why issue #20 surfaced as a bare interpreter
+  message. Every tool is now registered behind `_tool_boundary`, which
+  converts anything unhandled into
+  `ERROR: internal error in <tool> (<ExceptionType>): …`. It is a backstop,
+  not a substitute for handling: the wording keeps a defect legible as a
+  defect rather than disguising it as input rejection.
 
 - **A session holding both string and integer item ids crashed `oboe_next`
   and `oboe_list_items`.** `id` is documented as "string or integer" and both

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,50 @@ The format is based on Keep a Changelog and this project uses Semantic Versionin
 
 ### Fixed
 
+- **A non-numeric priority factor crashed the server instead of being
+  rejected** ([#20](https://github.com/Warnes-Innovations/oboe-mcp/issues/20)).
+  `_recalc_priority` added caller-supplied `urgency`/`importance`/`effort`/
+  `dependencies` straight into the `priority_score` arithmetic, so a string
+  `dependencies` surfaced to the MCP client as
+  `unsupported operand type(s) for +: 'int' and 'str'` — naming neither the
+  offending item nor the offending field.
+
+  **Validation at the input boundary.** `validate_score_components()` runs on
+  every caller-supplied item before anything is written, and rejects a bad
+  value with `item 'example': 'dependencies' must be a number 0-5 (got str:
+  '...')`. Applied in `create_session`, `merge_items`, `create_child_session`
+  and `update_field` — i.e. `oboe_create`, `oboe_merge_items`,
+  `oboe_create_child_session` and `oboe_update_field`. Validation happens
+  *before* the transaction opens, so a rejected batch writes nothing and
+  appends nothing. As a second layer, the arithmetic itself now checks each
+  component's type, so no route into it — including an old session file — can
+  produce a bare `TypeError`.
+
+  Booleans, containers, `null`, fractional floats and — at the JSON tools —
+  numeric strings are all rejected rather than coerced. `oboe_update_field`
+  and `oboe-cli update` still accept a numeric string, because their `value`
+  arrives from `argv` or a `str`-typed MCP parameter; a non-numeric one is
+  now rejected by name instead of by `invalid literal for int()`.
+
+  The 0-5 range is enforced on **input only**. Nothing ever bounded these
+  values on disk, so applying the range to the load path would make a
+  previously readable session file unloadable.
+
+- **`oboe_create` accepted duplicate item ids; `oboe_merge_items` rejected
+  them.** A second item sharing an id is unreachable — every lookup resolves
+  to the first — so it could never be completed or skipped and the session
+  could never finish. Worse, `oboe_next(mark_in_progress=True)` returned the
+  shadowed item and then marked the *other* one in progress. Both paths now
+  share `_stage_items`, which validates ids, rejects duplicates, and assigns
+  auto-ids only after every explicit id in the batch is known — so `[{},
+  {"id": 1}]` no longer produces two items numbered 1. An id must be a string
+  or an integer; `null` is rejected with a message saying to omit the field.
+
+- **`oboe_update_field` could rewrite `id` into a collision, and accepted any
+  field name at all.** Setting `id` is now refused outright, and the field
+  name is checked against the documented item schema instead of being written
+  through.
+
 - **`oboe-cli next --mark-in-progress` crashed on a session with no actionable
   items.** `_cmd_next` dereferenced `item["id"]` before `_print_next`'s
   `item is None` branch could report "No actionable items", so `get_next()`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -144,6 +144,35 @@ The format is based on Keep a Changelog and this project uses Semantic Versionin
   not a substitute for handling: the wording keeps a defect legible as a
   defect rather than disguising it as input rejection.
 
+- **An atomic write was not a durable one.** `atomic_write_json` fsynced the
+  temp file and then `os.replace`d it into position, which makes the swap
+  atomic *for a concurrent reader* but not durable: on POSIX the new name
+  lives in the directory entry, and that entry only reaches disk when the
+  directory itself is fsynced. A crash could leave the old file after a write
+  that had returned successfully. The directory is now fsynced too, best
+  effort — Windows cannot open a directory for fsync, and the write has
+  already succeeded, so failing there would turn a durability nicety into a
+  lost operation.
+
+- **`migrate` truncated the user's own instruction files in place.**
+  `Path.write_text` truncates before writing, so a crash — or a reader —
+  between the two saw an empty or partial file. These are files the tool did
+  not create and cannot reconstruct, and a migration is exactly when someone
+  is already repairing something. It now writes via a temp file and
+  `os.replace`, preserving the destination's mode. The routine is duplicated
+  rather than imported from `locking`, deliberately: `migrate` is documented
+  to run on the stock macOS `python3` (3.9), and `locking` evaluates
+  `float | None` annotations at runtime and so needs 3.10+.
+
+- **A lock timeout was compared before it was type-checked.**
+  `oboe_set_lock_policy` evaluated `timeout_seconds <= 0`, which raises
+  `TypeError` against a string — surfacing from inside lock acquisition, where
+  it reads as a concurrency failure rather than a bad argument. No shipping
+  caller could reach it (pydantic coerces the MCP parameter, and `oboe-cli`
+  parses `--lock-timeout` itself), but reachability is a fact about today's
+  callers, not about whether the code is right. `locking._coerce_timeout` now
+  validates at the library boundary and the tool checks before comparing.
+
 - **A session holding both string and integer item ids crashed `oboe_next`
   and `oboe_list_items`.** `id` is documented as "string or integer" and both
   `oboe_create` and `oboe_merge_items` accept whatever the caller supplies, so

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -71,6 +71,25 @@ The format is based on Keep a Changelog and this project uses Semantic Versionin
   name is checked against the documented item schema instead of being written
   through.
 
+- **A session holding both string and integer item ids crashed `oboe_next`
+  and `oboe_list_items`.** `id` is documented as "string or integer" and both
+  `oboe_create` and `oboe_merge_items` accept whatever the caller supplies, so
+  one session can legitimately hold `2` and `"phase-1"`. Both sort keys ended
+  in the raw id, so ordering them raised
+  `TypeError: '<' not supported between instances of 'int' and 'str'`.
+
+  It stayed latent because the id is only a *tie-break* on `priority_score`:
+  a mixed-id session works until two of its items happen to score the same,
+  and then every listing of it fails at once. `_id_sort_key` now gives a total
+  order — numeric ids first and in numeric order (a string that spells a
+  number counts as that number, matching how `merge_items` already picks the
+  next id), then the rest as text.
+
+- **The same class in `oboe-cli status`.** `category` is free-form and never
+  type-checked, so `sorted(categories.items())` crashed identically on a
+  session mixing `5` with `"General"` — taking down a read-only display. It
+  now sorts on `str()` of the key.
+
 - **`oboe-cli next --mark-in-progress` crashed on a session with no actionable
   items.** `_cmd_next` dereferenced `item["id"]` before `_print_next`'s
   `item is None` branch could report "No actionable items", so `get_next()`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,6 +56,21 @@ The format is based on Keep a Changelog and this project uses Semantic Versionin
   values on disk, so applying the range to the load path would make a
   previously readable session file unloadable.
 
+- **`trim_sessions` deleted files outside the sessions directory.** It joined
+  each `index.json` row's `file` onto the sessions directory and unlinked the
+  result, unchecked. A row of `../../IMPORTANT.txt` destroyed that file and
+  still reported it as a deleted session. `index.json` is routinely committed
+  and synced between machines, so its contents are not this code's to trust.
+
+  `_deletable_session` now applies three independent checks and refuses on any
+  one: the name must match `session_YYYYMMDD_HHMMSS.json`, must be a bare
+  filename, and must resolve with the sessions directory as its parent — the
+  last being what catches a symlink pointing out of the tree, which neither
+  name check can see. Refused rows are reported under a new `rejected` key
+  rather than dropped, and `deleted` now lists what was actually unlinked
+  instead of what was selected (a row with no `file` was previously counted as
+  a deletion that never happened).
+
 - **`oboe_create` accepted duplicate item ids; `oboe_merge_items` rejected
   them.** A second item sharing an id is unreachable — every lookup resolves
   to the first — so it could never be completed or skipped and the session
@@ -70,6 +85,12 @@ The format is based on Keep a Changelog and this project uses Semantic Versionin
   field name at all.** Setting `id` is now refused outright, and the field
   name is checked against the documented item schema instead of being written
   through.
+
+- **`oboe_trim_sessions` crashed on a timezone-aware `before`.** `created` is
+  parsed from a bare `YYYY-MM-DD` and is naive, so an ISO-8601 string with an
+  offset — the likeliest form for a machine to emit — raised
+  `TypeError: can't compare offset-naive and offset-aware datetimes` from
+  inside a delete operation. An aware cutoff is now converted to local naive.
 
 - **A session holding both string and integer item ids crashed `oboe_next`
   and `oboe_list_items`.** `id` is documented as "string or integer" and both

--- a/docs/SESSION_FORMAT.md
+++ b/docs/SESSION_FORMAT.md
@@ -225,6 +225,7 @@ Index maintenance behavior:
 
 - Mutating session operations update the corresponding `index.json` entry.
 - Listing sessions can rebuild the entire index when the stored index is absent or invalid.
+- An index is *invalid* if any row is not an object carrying a string `file`, not merely if the top level is wrong. Such rows are never consumed; the index is rebuilt from the session files instead.
 - `oboe_trim_sessions` deletes only rows whose `file` is a bare, well-formed session filename that resolves inside the sessions directory. Anything else — a path, a traversal, a symlink out of the tree — is refused, reported under `rejected`, and left on disk. Its `deleted` list records what was actually removed, not what was selected.
 - `index.json` should be treated as a managed artifact, not hand-edited application state.
 

--- a/docs/SESSION_FORMAT.md
+++ b/docs/SESSION_FORMAT.md
@@ -225,6 +225,7 @@ Index maintenance behavior:
 
 - Mutating session operations update the corresponding `index.json` entry.
 - Listing sessions can rebuild the entire index when the stored index is absent or invalid.
+- `oboe_trim_sessions` deletes only rows whose `file` is a bare, well-formed session filename that resolves inside the sessions directory. Anything else — a path, a traversal, a symlink out of the tree — is refused, reported under `rejected`, and left on disk. Its `deleted` list records what was actually removed, not what was selected.
 - `index.json` should be treated as a managed artifact, not hand-edited application state.
 
 ## Lifecycle Notes

--- a/docs/SESSION_FORMAT.md
+++ b/docs/SESSION_FORMAT.md
@@ -92,10 +92,10 @@ Each entry in `items` is a JSON object with these fields.
 | `title` | string | yes | Short label for the item. Defaults to `Item {id}`. |
 | `category` | string | yes | Category label. Defaults to `General`. |
 | `description` | string | yes | Free-text detail for the item. Defaults to the empty string. |
-| `urgency` | integer | yes | Priority input, default `3`. |
-| `importance` | integer | yes | Priority input, default `3`. |
-| `effort` | integer | yes | Priority input, default `3`. |
-| `dependencies` | integer | yes | Priority input, default `1`. |
+| `urgency` | integer | yes | Priority input, `0`-`5`, default `3`. See [Score components](#score-components). |
+| `importance` | integer | yes | Priority input, `0`-`5`, default `3`. See [Score components](#score-components). |
+| `effort` | integer | yes | Priority input, `0`-`5`, default `3`. Higher effort *lowers* the score. |
+| `dependencies` | integer | yes | Priority input, `0`-`5`, default `1`. Dependency **pressure** as a number — not a description of what the item depends on. |
 | `priority_score` | integer | yes | Derived score computed from the priority inputs. |
 | `resolution` | string or null | yes | Completion text set by `oboe_mark_complete`, otherwise `null`. |
 | `skip_reason` | string or null | yes | Skip reason set by `oboe_mark_skip`, otherwise `null`. |
@@ -166,6 +166,24 @@ The priority score is recalculated with this formula:
 $$
 priority\_score = urgency + importance + (6 - effort) + dependencies
 $$
+
+### Score components
+
+All four components are integers. On input they must be numbers in the range
+**0-5**; a non-numeric or out-of-range value is rejected with an error naming
+the item and the field, and nothing is written.
+
+| Component | Default | Meaning |
+| --- | --- | --- |
+| `urgency` | 3 | How time-sensitive the item is. Higher sorts first. |
+| `importance` | 3 | How much the item matters. Higher sorts first. |
+| `effort` | 3 | How much work the item is. Higher effort *lowers* the score, because the formula uses `6 - effort`. |
+| `dependencies` | 1 | How much other work is waiting on this item — dependency **pressure**, expressed as a number. It is **not** a description of what the item depends on; that belongs in `description`. |
+
+The 0-5 range is enforced on input only. Session files written before the
+range existed may hold values outside it, and still load — the component type
+is checked on every read, but the range is not, so an older file does not
+become unreadable.
 
 Sorting rules used by the session helpers:
 

--- a/docs/SESSION_FORMAT.md
+++ b/docs/SESSION_FORMAT.md
@@ -87,7 +87,7 @@ Each entry in `items` is a JSON object with these fields.
 
 | Field | Type | Required | Meaning |
 | --- | --- | --- | --- |
-| `id` | string or integer | yes | Item identifier. If omitted during creation, oboe-mcp assigns a sequential integer starting at 1. |
+| `id` | string or integer | yes | Item identifier, unique within the session. If omitted, oboe-mcp assigns the lowest free integer. Any other type — including `null` — is rejected on input; omit the field to have one assigned. Cannot be changed with `oboe_update_field`. |
 | `status` | string | yes | Lifecycle status: `pending`, `in_progress`, `deferred`, `blocked`, `completed`, or `skipped`. |
 | `title` | string | yes | Short label for the item. Defaults to `Item {id}`. |
 | `category` | string | yes | Category label. Defaults to `General`. |
@@ -106,6 +106,14 @@ Each entry in `items` is a JSON object with these fields.
 | `approved_at` | string or null | yes | ISO 8601 timestamp set when approval is recorded, otherwise `null`. |
 | `approval_note` | string or null | yes | Optional note explaining the approval decision. |
 | `child_session_resolution` | string | conditional | Optional resolution note copied back to the parent item when a child session is completed with a resolution string. |
+
+Item ids must be unique within a session. A duplicate is rejected on input by
+both `oboe_create` and `oboe_merge_items`, because every lookup resolves to the
+first match — a second item sharing an id can never be addressed, completed, or
+skipped, so the session could never reach `completed`.
+
+`oboe_update_field` accepts only the field names in the table above, and not
+`id`. An unrecognised field name is rejected rather than stored.
 
 Normalization defaults:
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,7 @@ classifiers = [
 	"Topic :: Software Development :: Libraries :: Python Modules",
 	"Typing :: Typed",
 ]
-dependencies = ["mcp>=2.0,<3"]
+dependencies = ["mcp>=2.0,<3", "pydantic>=2.0,<3"]
 
 [project.urls]
 Homepage = "https://github.com/Warnes-Innovations/oboe-mcp"

--- a/src/oboe_mcp/cli.py
+++ b/src/oboe_mcp/cli.py
@@ -677,7 +677,10 @@ def _cmd_create(args: argparse.Namespace, parser: argparse.ArgumentParser) -> in
             title=args.title,
             description=args.description,
         )
-    except FileExistsError as exc:
+    except (FileExistsError, ValueError, KeyError) as exc:
+        # ValueError covers item validation (score components, status); its
+        # siblings _cmd_merge and _cmd_create_child already caught it, and
+        # main() does not, so it escaped from here as a bare traceback.
         print(f"❌ {exc}", file=sys.stderr)
         return 1
     print(f"✓ Session created: {sf.name}")

--- a/src/oboe_mcp/cli.py
+++ b/src/oboe_mcp/cli.py
@@ -190,7 +190,12 @@ def _print_session_status(stats: dict) -> None:
     categories = stats.get("categories", {})
     if categories:
         print("\nBy Category:")
-        for cat, counts in sorted(categories.items()):
+        # Sort on str(), not the raw key.  `category` is free-form caller
+        # input and is never type-checked, so one session can hold both 5 and
+        # "General" — and ordering those directly raises TypeError, taking
+        # down a read-only status display.  Same class as _id_sort_key.
+        by_name = sorted(categories.items(), key=lambda kv: str(kv[0]))
+        for cat, counts in by_name:
             cat_total = counts.get("total", 0)
             cat_done  = counts.get("completed", 0)
             cat_pct   = (100 * cat_done // cat_total) if cat_total else 0

--- a/src/oboe_mcp/cli.py
+++ b/src/oboe_mcp/cli.py
@@ -770,6 +770,22 @@ def _cmd_trim_sessions(args: argparse.Namespace, parser: argparse.ArgumentParser
         print(f"  - {name}")
     if result["total_retained"]:
         print(f"Retained: {result['total_retained']} session(s)")
+    # A refused row must be reported, never dropped: it means index.json names
+    # something this command declined to delete, and silence would read as
+    # "nothing to see" on a destructive operation.
+    if result.get("total_rejected"):
+        print(
+            f"\n⚠️  Refused {result['total_rejected']} index row(s) — "
+            "not deleted:",
+            file=sys.stderr,
+        )
+        for note in result["rejected"]:
+            print(f"  - {note}", file=sys.stderr)
+        print(
+            "Run 'oboe-cli reindex' to rebuild index.json from the session "
+            "files on disk.",
+            file=sys.stderr,
+        )
     return 0
 
 

--- a/src/oboe_mcp/cli.py
+++ b/src/oboe_mcp/cli.py
@@ -1084,6 +1084,19 @@ def main(argv: Sequence[str] | None = None) -> int:
     except LockError as exc:
         print(f"❌ {exc}", file=sys.stderr)
         return 1
+    except (ValueError, KeyError) as exc:
+        # The domain errors: a rejected value, a malformed session file, a
+        # missing item.  Handlers that want a more specific message still
+        # catch these themselves; this is the backstop for the ones that do
+        # not, of which there were eight — `status`, `list` and `show` all
+        # printed a traceback for a session file that was merely malformed.
+        #
+        # Deliberately NOT a blanket `except Exception`.  Unlike the MCP
+        # server, whose client cannot act on a traceback, a CLI traceback is
+        # the conventional and useful signal that something is a defect rather
+        # than bad input — so an unexpected type should still surface as one.
+        print(f"❌ {exc}", file=sys.stderr)
+        return 1
 
 
 if __name__ == "__main__":

--- a/src/oboe_mcp/locking.py
+++ b/src/oboe_mcp/locking.py
@@ -59,6 +59,7 @@ import threading
 import time
 from contextlib import contextmanager
 from dataclasses import dataclass
+from math import isfinite
 from pathlib import Path
 
 try:  # POSIX
@@ -77,6 +78,7 @@ __all__ = [
     "LockPolicy",
     "LockTimeout",
     "atomic_write_json",
+    "atomic_write_text",
     "get_default_policy",
     "have_real_locking",
     "policy",
@@ -177,13 +179,39 @@ def get_default_policy() -> LockPolicy:
     return override if override is not None else _default_policy
 
 
+def _coerce_timeout(timeout: object) -> float | None:
+    """Validate a caller-supplied lock timeout.
+
+    ``None`` means wait forever.  Anything else must be a real number; a string
+    is rejected rather than compared, because ``timeout <= 0`` against a string
+    raises ``TypeError`` from inside lock acquisition, where it reads as a
+    concurrency failure rather than a bad argument.
+    """
+    if timeout is None:
+        return None
+    if isinstance(timeout, bool) or not isinstance(timeout, (int, float)):
+        raise ValueError(
+            "Lock timeout must be a number of seconds or None (got "
+            f"{type(timeout).__name__}: {timeout!r})"
+        )
+    if not isfinite(timeout):
+        raise ValueError(f"Lock timeout must be finite (got {timeout!r})")
+    return float(timeout)
+
+
 def set_default_policy(
     blocking: bool = True,
     timeout: float | None = DEFAULT_TIMEOUT,
 ) -> LockPolicy:
-    """Set the process-wide default lock policy and return it."""
+    """Set the process-wide default lock policy and return it.
+
+    Raises:
+        ValueError: *timeout* is neither None nor a finite number.
+    """
     global _default_policy
-    _default_policy = LockPolicy(blocking=blocking, timeout=timeout)
+    _default_policy = LockPolicy(
+        blocking=bool(blocking), timeout=_coerce_timeout(timeout)
+    )
     return _default_policy
 
 
@@ -219,13 +247,33 @@ def supports_shared_locks() -> bool:
 # Atomic write
 # ---------------------------------------------------------------------------
 
-def atomic_write_json(path: Path, data: object, indent: int = 2) -> None:
-    """Serialize *data* to *path* atomically.
+def _fsync_dir(directory: Path) -> None:
+    """Flush a directory entry so a completed rename survives a power loss.
 
-    The JSON is written to a temporary file in the same directory, flushed and
-    fsynced, then moved into place with :func:`os.replace`.  A concurrent
-    reader sees either the previous file or the new one, never a truncated or
-    partial one.
+    ``os.replace`` makes the swap atomic *with respect to other readers*, which
+    is not the same as durable: on POSIX the new name lives in the directory
+    entry, and that entry is only guaranteed on disk once the directory itself
+    is fsynced.  Without this, a crash can leave the old file — or, on some
+    filesystems, neither — after a write that returned successfully.
+
+    Best effort by design.  Directories cannot be opened for fsync on Windows,
+    and some filesystems reject it; the write itself has already succeeded, so
+    failing here would turn a durability nicety into a lost operation.
+    """
+    with contextlib.suppress(OSError, AttributeError):
+        fd = os.open(directory, getattr(os, "O_DIRECTORY", os.O_RDONLY))
+        try:
+            os.fsync(fd)
+        finally:
+            os.close(fd)
+
+
+def _atomic_write(path: Path, render) -> None:
+    """Write *path* via a same-directory temp file and :func:`os.replace`.
+
+    *render* receives the open text handle.  Shared by the JSON and plain-text
+    writers so both get the same flush/fsync/replace/fsync-dir sequence — a
+    second copy of this dance is a second place for it to be wrong.
     """
     path = Path(path)
     path.parent.mkdir(parents=True, exist_ok=True)
@@ -238,15 +286,39 @@ def atomic_write_json(path: Path, data: object, indent: int = 2) -> None:
     tmp_path: str | None = tmp_name
     try:
         with os.fdopen(fd, "w", encoding="utf-8") as handle:
-            json.dump(data, handle, indent=indent)
+            render(handle)
             handle.flush()
             os.fsync(handle.fileno())
         os.replace(tmp_name, path)
         tmp_path = None  # ownership transferred to the destination
+        _fsync_dir(path.parent)
     finally:
         if tmp_path is not None:
             with contextlib.suppress(OSError):
                 os.unlink(tmp_path)
+
+
+def atomic_write_json(path: Path, data: object, indent: int = 2) -> None:
+    """Serialize *data* to *path* atomically and durably.
+
+    The JSON is written to a temporary file in the same directory, flushed and
+    fsynced, moved into place with :func:`os.replace`, and the directory is
+    then fsynced so the rename itself survives a crash.  A concurrent reader
+    sees either the previous file or the new one, never a truncated or
+    partial one.
+    """
+    _atomic_write(path, lambda handle: json.dump(data, handle, indent=indent))
+
+
+def atomic_write_text(path: Path, text: str) -> None:
+    """Write *text* to *path* atomically and durably.
+
+    The same guarantee as :func:`atomic_write_json`, for callers rewriting a
+    file that is not JSON.  ``Path.write_text`` truncates in place: a reader —
+    or a crash — between the truncate and the write sees an empty or partial
+    file, and for a file the tool did not create that is the user's content.
+    """
+    _atomic_write(path, lambda handle: handle.write(text))
 
 
 # ---------------------------------------------------------------------------

--- a/src/oboe_mcp/migrate.py
+++ b/src/oboe_mcp/migrate.py
@@ -44,7 +44,9 @@ from __future__ import annotations
 import argparse
 import os
 import re
+import shutil
 import sys
+import tempfile
 from dataclasses import dataclass, field
 from pathlib import Path
 
@@ -120,6 +122,52 @@ def _candidate_files(root: Path) -> list[Path]:
 
     # Stable, de-duplicated order so output is reproducible.
     return sorted(set(found))
+
+
+def _atomic_write_text(path: Path, text: str) -> None:
+    """Replace *path*'s contents via a temp file and ``os.replace``.
+
+    ``Path.write_text`` truncates in place, so a crash — or a reader — between
+    the truncate and the write sees an empty or partial file.  These are the
+    user's own instruction files, which this module did not create and cannot
+    reconstruct, and a migration is precisely when someone is already repairing
+    something.  The directory is fsynced afterwards so the rename is durable
+    and not merely atomic.
+
+    Duplicated from ``locking.atomic_write_text`` rather than imported, and
+    that is deliberate: this module is documented to run on the stock macOS
+    ``python3`` (3.9), while ``locking`` evaluates ``float | None`` annotations
+    at runtime and therefore needs 3.10+.  Importing it would break the repair
+    tool on exactly the interpreter it was written to survive.
+    """
+    directory = path.parent
+    fd, tmp_name = tempfile.mkstemp(
+        dir=str(directory), prefix="." + path.name + ".", suffix=".tmp"
+    )
+    tmp_path: "str | None" = tmp_name
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as handle:
+            handle.write(text)
+            handle.flush()
+            os.fsync(handle.fileno())
+        shutil.copymode(str(path), tmp_name)
+        os.replace(tmp_name, str(path))
+        tmp_path = None  # ownership transferred to the destination
+        try:  # best effort: not supported on Windows or every filesystem
+            flags = getattr(os, "O_DIRECTORY", os.O_RDONLY)
+            dir_fd = os.open(str(directory), flags)
+            try:
+                os.fsync(dir_fd)
+            finally:
+                os.close(dir_fd)
+        except OSError:
+            pass
+    finally:
+        if tmp_path is not None:
+            try:
+                os.unlink(tmp_path)
+            except OSError:
+                pass
 
 
 def _migrate_sessions_dir(root: Path, result: MigrationResult) -> None:
@@ -219,7 +267,7 @@ def migrate_project(
             continue
 
         if not dry_run:
-            path.write_text(updated, encoding="utf-8")
+            _atomic_write_text(path, updated)
         result.changed.append(rel)
 
     return result

--- a/src/oboe_mcp/server.py
+++ b/src/oboe_mcp/server.py
@@ -28,6 +28,7 @@ from oboe_mcp.migrate import format_result, migrate_project
 from oboe_mcp.locking import (
     DEFAULT_TIMEOUT,
     LockError,
+    _coerce_timeout,
     get_default_policy,
     set_default_policy,
     supports_shared_locks,
@@ -1180,10 +1181,15 @@ def oboe_set_lock_policy(
         timeout: float | None
         if timeout_seconds is None:
             timeout = DEFAULT_TIMEOUT
-        elif timeout_seconds <= 0:
-            timeout = None
         else:
-            timeout = float(timeout_seconds)
+            # Check the type before comparing.  Pydantic coerces this argument
+            # for a real MCP client, so a string cannot arrive that way — but
+            # `timeout_seconds <= 0` against one is wrong code regardless of
+            # who can currently reach it, and the next caller (a test, another
+            # module, a future transport) is not bound by today's schema.
+            timeout = _coerce_timeout(timeout_seconds)
+            if timeout is not None and timeout <= 0:
+                timeout = None
 
         applied = set_default_policy(blocking=blocking, timeout=timeout)
         return json.dumps({

--- a/src/oboe_mcp/server.py
+++ b/src/oboe_mcp/server.py
@@ -18,9 +18,10 @@ import os
 import sys
 from datetime import datetime
 from pathlib import Path
-from typing import Optional, Sequence
+from typing import Annotated, Optional, Sequence
 
 from mcp.server.mcpserver import MCPServer
+from pydantic import Field
 
 from oboe_mcp.migrate import format_result, migrate_project
 from oboe_mcp.locking import (
@@ -59,6 +60,107 @@ from oboe_mcp.session import (
 
 mcp = MCPServer("oboe-mcp", instructions="One-By-One session management tools")
 
+
+# ---------------------------------------------------------------------------
+# Item input schema
+# ---------------------------------------------------------------------------
+#
+# Every tool that accepts caller-supplied items publishes this schema, so a
+# client can see that the four priority factors are NUMBERS before it sends a
+# sentence.  `dependencies` reads like "what this item depends on", and that
+# misreading is what issue #20 was: a descriptive string reached the
+# priority_score arithmetic and crashed it.
+#
+# The schema is advisory — MCP clients are not obliged to enforce it — so
+# session.validate_score_components() re-checks every value on arrival.
+
+_SCORE_FIELD_DOC = {
+    "urgency": "How time-sensitive this item is. Higher sorts first.",
+    "importance": "How much this item matters. Higher sorts first.",
+    "effort": (
+        "How much work this item is. Higher means MORE work and sorts "
+        "LATER (the score uses 6 - effort)."
+    ),
+    "dependencies": (
+        "How much other work is waiting on this item — dependency "
+        "PRESSURE, as a number. NOT a description of what this item "
+        "depends on. Higher sorts first."
+    ),
+}
+
+_SCORE_DEFAULTS = {
+    "urgency": 3, "importance": 3, "effort": 3, "dependencies": 1,
+}
+
+ITEM_INPUT_SCHEMA: dict = {
+    "type": "object",
+    "properties": {
+        "id": {
+            "type": ["string", "integer"],
+            "description": (
+                "Item identifier. Assigned sequentially from 1 if omitted."
+            ),
+        },
+        "title": {"type": "string", "description": "Short label."},
+        "description": {"type": "string", "description": "Free-text detail."},
+        "category": {"type": "string", "description": "Category label."},
+        "status": {
+            "type": "string",
+            "enum": [
+                "pending", "in_progress", "deferred",
+                "blocked", "completed", "skipped",
+            ],
+            "description": "Lifecycle status. Defaults to 'pending'.",
+        },
+        **{
+            field: {
+                "type": "number",
+                "minimum": 0,
+                "maximum": 5,
+                "default": _SCORE_DEFAULTS[field],
+                "description": (
+                    f"Priority factor, integer 0-5 (default "
+                    f"{_SCORE_DEFAULTS[field]}). {doc}"
+                ),
+            }
+            for field, doc in _SCORE_FIELD_DOC.items()
+        },
+    },
+    "additionalProperties": True,
+}
+
+_ITEMS_DESCRIPTION = (
+    "List of item dicts. All fields are optional. The four priority factors "
+    "-- urgency, importance, effort, dependencies -- are NUMBERS in the range "
+    "0-5, not text; a non-numeric value is rejected naming the item and the "
+    "field. In particular 'dependencies' is a numeric measure of dependency "
+    "pressure, NOT a description of what the item depends on -- put that in "
+    "'description'. priority_score = urgency + importance + (6 - effort) + "
+    "dependencies."
+)
+
+
+def _inject_item_schema(schema: dict) -> None:
+    """Attach ITEM_INPUT_SCHEMA to a ``list[dict]`` parameter's schema.
+
+    Pydantic renders ``Optional[list[dict]]`` as an ``anyOf`` of an array
+    branch and a null branch, so the array branch is what needs the item
+    schema; a required ``list[dict]`` has no ``anyOf`` and is patched directly.
+    """
+    for branch in schema.get("anyOf", []):
+        if branch.get("type") == "array":
+            branch["items"] = ITEM_INPUT_SCHEMA
+    if schema.get("type") == "array":
+        schema["items"] = ITEM_INPUT_SCHEMA
+
+
+_ITEMS_FIELD = Field(
+    description=_ITEMS_DESCRIPTION,
+    json_schema_extra=_inject_item_schema,
+)
+
+ItemList = Annotated[list[dict], _ITEMS_FIELD]
+OptionalItemList = Annotated[Optional[list[dict]], _ITEMS_FIELD]
 
 # LockError is included so a contended session surfaces to the calling agent
 # as a normal tool error it can act on, rather than an unhandled exception.
@@ -138,7 +240,7 @@ def oboe_create(
     base_dir: str,
     title: str,
     description: str,
-    items: Optional[list[dict]] = None,
+    items: OptionalItemList = None,
     session_file: Optional[str] = None,
 ) -> str:
     """Create a new OBO session file and update index.json atomically.
@@ -147,9 +249,28 @@ def oboe_create(
         base_dir: Project root directory.
         title: Human-readable session title
         description: What this session is reviewing
-        items: List of item dicts. All priority fields are optional.
-               If omitted, the session is created with no items (items can
-               be added later with oboe_merge_items).
+        items: List of item dicts. Every field is optional; if items is
+               omitted entirely the session is created empty (items can be
+               added later with oboe_merge_items).
+
+               The four priority factors are NUMBERS in the range 0-5:
+
+                 urgency      integer 0-5, default 3 — time sensitivity
+                 importance   integer 0-5, default 3 — how much it matters
+                 effort       integer 0-5, default 3 — how much work it is
+                 dependencies integer 0-5, default 1 — how much other work
+                              is waiting on this item (dependency PRESSURE)
+
+               'dependencies' is a numeric score, NOT a description of what
+               the item depends on — that belongs in 'description'. A
+               non-numeric or out-of-range value is rejected with an error
+               naming the item and the field; nothing is written.
+
+               priority_score = urgency + importance + (6 - effort)
+                                + dependencies
+
+               Higher effort therefore lowers the score. Other accepted
+               fields: id, title, description, category, status.
         session_file: Optional explicit filename.
                       If omitted, generated from current timestamp.
     """
@@ -738,7 +859,7 @@ def oboe_create_child_session(
     parent_session_file: str,
     title: str,
     description: str,
-    items: Optional[list[dict]] = None,
+    items: OptionalItemList = None,
     base_dir: Optional[str] = None,
     parent_item_id: Optional[str] = None,
     session_file: Optional[str] = None,
@@ -749,8 +870,11 @@ def oboe_create_child_session(
         parent_session_file: Parent session path or filename
         title: Human-readable child session title
         description: What the child session is reviewing
-        items: Child session items. If omitted, the child session is created
-               with no items (items can be added later with oboe_merge_items).
+        items: Child session items, same shape as oboe_create. If omitted,
+               the child session is created with no items (items can be added
+               later with oboe_merge_items). The four priority factors
+               (urgency, importance, effort, dependencies) are NUMBERS in the
+               range 0-5, not text.
         base_dir: Required if session paths are bare filenames
         parent_item_id: Optional parent item to block while child is active
         session_file: Optional explicit child session filename
@@ -832,14 +956,20 @@ def oboe_complete_child_session(
 @mcp.tool()
 def oboe_merge_items(
     session_file: str,
-    items: list[dict],
+    items: ItemList,
     base_dir: Optional[str] = None,
 ) -> str:
     """Append new items to an existing session.
 
     Args:
         session_file: Absolute path or filename relative to the sessions dir.
-        items: List of item dicts to append to the session
+        items: List of item dicts to append. Same shape as oboe_create: the
+               four priority factors (urgency, importance, effort,
+               dependencies) are NUMBERS in the range 0-5, not text, and
+               'dependencies' measures dependency pressure rather than
+               naming what the item depends on. A bad value rejects the
+               whole batch, naming the item and the field; no items are
+               appended.
         base_dir: Required if session_file is a bare filename
     """
     try:

--- a/src/oboe_mcp/server.py
+++ b/src/oboe_mcp/server.py
@@ -13,6 +13,7 @@ Uses MCPServer for concise tool registration.
 from __future__ import annotations
 
 import argparse
+import functools
 import json
 import os
 import sys
@@ -59,6 +60,45 @@ from oboe_mcp.session import (
 )
 
 mcp = MCPServer("oboe-mcp", instructions="One-By-One session management tools")
+
+
+# ---------------------------------------------------------------------------
+# Last-resort error boundary
+# ---------------------------------------------------------------------------
+
+def _tool_boundary(fn):
+    """Turn any exception a tool did not handle into a labelled error string.
+
+    Each tool catches what it *expects*; `_TOOL_EXCEPTIONS` covers OSError,
+    ValueError, JSONDecodeError and LockError.  Everything else — KeyError,
+    TypeError, AttributeError — propagated raw to the MCP client, which is
+    what issue #20 looked like from the outside:
+
+        Error executing tool oboe_create: unsupported operand type(s) for +
+
+    A raw interpreter error tells the caller nothing it can act on, and 14 of
+    the 23 tools did not even catch KeyError.  This is a backstop, not a
+    substitute for handling: the message says *internal error* and names the
+    exception type, so a defect that reaches here still reads as a defect
+    rather than as ordinary input rejection.
+    """
+    @functools.wraps(fn)
+    def wrapper(*args, **kwargs):
+        try:
+            return fn(*args, **kwargs)
+        except Exception as exc:  # noqa: BLE001 - deliberate outermost catch
+            return (
+                f"ERROR: internal error in {fn.__name__} "
+                f"({type(exc).__name__}): {exc}"
+            )
+    return wrapper
+
+
+def tool():
+    """Register an MCP tool behind :func:`_tool_boundary`."""
+    def decorate(fn):
+        return mcp.tool()(_tool_boundary(fn))
+    return decorate
 
 
 # ---------------------------------------------------------------------------
@@ -235,7 +275,7 @@ def _resolve(session_file: str, base_dir: str | None = None) -> Path:
 # Tool: oboe_create
 # ---------------------------------------------------------------------------
 
-@mcp.tool()
+@tool()
 def oboe_create(
     base_dir: str,
     title: str,
@@ -309,7 +349,7 @@ def oboe_create(
 # Tool: oboe_reindex
 # ---------------------------------------------------------------------------
 
-@mcp.tool()
+@tool()
 def oboe_reindex(base_dir: str, write: bool = True) -> str:
     """Rebuild index.json from the session files on disk.
 
@@ -350,7 +390,7 @@ def oboe_reindex(base_dir: str, write: bool = True) -> str:
 # Tool: oboe_list_sessions
 # ---------------------------------------------------------------------------
 
-@mcp.tool()
+@tool()
 def oboe_list_sessions(
     base_dir: str,
     status_filter: Optional[str] = None,
@@ -383,7 +423,7 @@ def oboe_list_sessions(
 # Tool: oboe_session_status
 # ---------------------------------------------------------------------------
 
-@mcp.tool()
+@tool()
 def oboe_session_status(
     session_file: str,
     base_dir: Optional[str] = None,
@@ -406,7 +446,7 @@ def oboe_session_status(
 # Tool: oboe_get_session
 # ---------------------------------------------------------------------------
 
-@mcp.tool()
+@tool()
 def oboe_get_session(
     session_file: str,
     base_dir: Optional[str] = None,
@@ -448,7 +488,7 @@ def oboe_get_session(
 # Tool: oboe_next
 # ---------------------------------------------------------------------------
 
-@mcp.tool()
+@tool()
 def oboe_next(
     session_file: str,
     base_dir: Optional[str] = None,
@@ -528,7 +568,7 @@ def oboe_next(
 # Tool: oboe_list_items
 # ---------------------------------------------------------------------------
 
-@mcp.tool()
+@tool()
 def oboe_list_items(
     session_file: str,
     base_dir: Optional[str] = None,
@@ -553,7 +593,7 @@ def oboe_list_items(
 # Tool: oboe_get_item
 # ---------------------------------------------------------------------------
 
-@mcp.tool()
+@tool()
 def oboe_get_item(
     session_file: str,
     item_id: str,
@@ -580,7 +620,7 @@ def oboe_get_item(
 # Tool: oboe_mark_complete
 # ---------------------------------------------------------------------------
 
-@mcp.tool()
+@tool()
 def oboe_mark_complete(
     session_file: str,
     item_id: str,
@@ -623,7 +663,7 @@ def oboe_mark_complete(
 # Tool: oboe_mark_skip
 # ---------------------------------------------------------------------------
 
-@mcp.tool()
+@tool()
 def oboe_mark_skip(
     session_file: str,
     item_id: str,
@@ -660,7 +700,7 @@ def oboe_mark_skip(
 # Tool: oboe_mark_deferred
 # ---------------------------------------------------------------------------
 
-@mcp.tool()
+@tool()
 def oboe_mark_deferred(
     session_file: str,
     item_id: str,
@@ -697,7 +737,7 @@ def oboe_mark_deferred(
 # Tool: oboe_mark_blocked
 # ---------------------------------------------------------------------------
 
-@mcp.tool()
+@tool()
 def oboe_mark_blocked(
     session_file: str,
     item_id: str,
@@ -736,7 +776,7 @@ def oboe_mark_blocked(
 # Tool: oboe_set_approval
 # ---------------------------------------------------------------------------
 
-@mcp.tool()
+@tool()
 def oboe_set_approval(
     session_file: str,
     item_id: str,
@@ -788,7 +828,7 @@ def oboe_set_approval(
 # ---------------------------------------------------------------------------
 
 
-@mcp.tool()
+@tool()
 def oboe_mark_in_progress(
     session_file: str,
     item_id: str,
@@ -821,7 +861,7 @@ def oboe_mark_in_progress(
         return f"ERROR: {e}"
 
 
-@mcp.tool()
+@tool()
 def oboe_complete_session(
     session_file: str,
     base_dir: Optional[str] = None,
@@ -854,7 +894,7 @@ def oboe_complete_session(
         return f"ERROR: {e}"
 
 
-@mcp.tool()
+@tool()
 def oboe_create_child_session(
     parent_session_file: str,
     title: str,
@@ -914,7 +954,7 @@ def oboe_create_child_session(
         return f"ERROR: {e}"
 
 
-@mcp.tool()
+@tool()
 def oboe_complete_child_session(
     child_session_file: str,
     base_dir: Optional[str] = None,
@@ -953,7 +993,7 @@ def oboe_complete_child_session(
         return f"ERROR: {e}"
 
 
-@mcp.tool()
+@tool()
 def oboe_merge_items(
     session_file: str,
     items: ItemList,
@@ -991,7 +1031,7 @@ def oboe_merge_items(
         return f"ERROR: {e}"
 
 
-@mcp.tool()
+@tool()
 def oboe_update_field(
     session_file: str,
     item_id: str,
@@ -1039,7 +1079,7 @@ def oboe_update_field(
         return f"ERROR: {e}"
 
 
-@mcp.tool()
+@tool()
 def oboe_cancel_session(
     session_file: str,
     base_dir: Optional[str] = None,
@@ -1069,7 +1109,7 @@ def oboe_cancel_session(
         return f"ERROR: {e}"
 
 
-@mcp.tool()
+@tool()
 def oboe_trim_sessions(
     base_dir: str,
     before: Optional[str] = None,
@@ -1115,7 +1155,7 @@ def oboe_trim_sessions(
 # ---------------------------------------------------------------------------
 # Tool: oboe_set_lock_policy
 # ---------------------------------------------------------------------------
-@mcp.tool()
+@tool()
 def oboe_set_lock_policy(
     blocking: bool = True,
     timeout_seconds: Optional[float] = DEFAULT_TIMEOUT,
@@ -1166,7 +1206,7 @@ def oboe_set_lock_policy(
 # ---------------------------------------------------------------------------
 # Tool: oboe_get_lock_policy
 # ---------------------------------------------------------------------------
-@mcp.tool()
+@tool()
 def oboe_get_lock_policy() -> str:
     """Report the lock policy currently in effect for this server process."""
     try:

--- a/src/oboe_mcp/server.py
+++ b/src/oboe_mcp/server.py
@@ -59,6 +59,7 @@ from oboe_mcp.session import (
 
 mcp = MCPServer("oboe-mcp", instructions="One-By-One session management tools")
 
+
 # LockError is included so a contended session surfaces to the calling agent
 # as a normal tool error it can act on, rather than an unhandled exception.
 _TOOL_EXCEPTIONS = (OSError, ValueError, json.JSONDecodeError, LockError)
@@ -874,9 +875,20 @@ def oboe_update_field(
     Args:
         session_file: Absolute path or filename relative to the sessions dir.
         item_id: Item ID to update
-        field: Field name (e.g. 'urgency', 'title', 'description',
-               'status', 'approval_status', 'approval_mode')
-        value: New value. Numeric score fields are cast automatically.
+        field: Field name. Must be one of the documented item fields:
+               title, category, description, status, urgency, importance,
+               effort, dependencies, priority_score, resolution, skip_reason,
+               blocker, blocked_at, approval_status, approval_mode,
+               approved_at, approval_note, child_session_resolution.
+               An unrecognised name is rejected rather than stored.
+               'id' cannot be changed — an id collision would make one of the
+               two items permanently unreachable.
+        value: New value, as a string. The four score components (urgency,
+               importance, effort, dependencies) must parse as a whole number
+               in the range 0-5 — "4" is fine, "high" or "blocks the cutover"
+               is rejected with an error naming the item and the field.
+               'dependencies' is dependency PRESSURE as a number, not a
+               description of what the item depends on.
         base_dir: Required if session_file is a bare filename
     """
     try:

--- a/src/oboe_mcp/session.py
+++ b/src/oboe_mcp/session.py
@@ -145,9 +145,65 @@ def load_session(session_file: Path) -> dict:
 
 
 def _load_session_unlocked(session_file: Path) -> dict:
-    """Read a session file assuming the caller already holds the lock."""
+    """Read a session file assuming the caller already holds the lock.
+
+    Raises:
+        ValueError: the file parses as JSON but is not a session document.
+    """
     with open(session_file, "r", encoding="utf-8") as f:
-        return json.load(f)
+        return _require_session_document(json.load(f), session_file)
+
+
+def _require_session_document(document: object, session_file: Path) -> dict:
+    """Check that *document* has the container shape the rest of this module
+    assumes, and say which file is wrong when it does not.
+
+    ``json.load`` only guarantees *valid JSON*, not a valid session.  Session
+    files are hand-editable, are synced between machines, and can be written by
+    other tooling, so a structurally wrong one is an ordinary occurrence rather
+    than an internal error.  Without this the shape was discovered by whatever
+    touched it first, in the vocabulary of the interpreter rather than of the
+    session store:
+
+    ======================  =======================================
+    file contains           error the caller used to see
+    ======================  =======================================
+    ``"items": "oops"``     dictionary update sequence element #0…
+    ``"items": [null]``     'NoneType' object is not iterable
+    a top-level list        'list' object has no attribute 'get'
+    ======================  =======================================
+
+    Only the containers are checked here.  Field-level rules stay in
+    :func:`_normalize_item`, which has to keep loading older files whose values
+    predate a constraint — see :func:`_score_value`.
+    """
+    where = f"Malformed session file {session_file.name}"
+    if not isinstance(document, dict):
+        raise ValueError(
+            f"{where}: expected a JSON object, got "
+            f"{type(document).__name__}"
+        )
+
+    items = document.get("items", [])
+    if not isinstance(items, list):
+        raise ValueError(
+            f"{where}: 'items' must be a list, got {type(items).__name__}"
+        )
+    for position, item in enumerate(items, start=1):
+        if not isinstance(item, dict):
+            raise ValueError(
+                f"{where}: item #{position} must be an object, got "
+                f"{type(item).__name__}"
+            )
+
+    children = document.get("child_session_files", [])
+    if not isinstance(children, list):
+        raise ValueError(
+            f"{where}: 'child_session_files' must be a list, got "
+            f"{type(children).__name__}"
+        )
+
+    return document
 
 
 def save_session(session_file: Path, session: dict) -> None:
@@ -531,12 +587,32 @@ def _index_path(sessions_dir: Path) -> Path:
     return sessions_dir / "index.json"
 
 
+def _is_valid_row(row: object) -> bool:
+    """Return True if *row* is usable as an index entry.
+
+    A row is only ever consumed by ``file``, so that is what has to be there
+    and has to be a string.
+    """
+    return isinstance(row, dict) and isinstance(row.get("file"), str)
+
+
 def _is_valid_index(index: object) -> bool:
-    """Return True if *index* has the expected top-level structure."""
+    """Return True if *index* has the expected structure, rows included.
+
+    The row check is not incidental.  Validating only the top level let a
+    structurally-valid index carry unusable rows straight into code that
+    assumes the shape: ``_upsert_index`` raised ``TypeError: string indices
+    must be integers`` — *after* the session file had already been written, so
+    every write path left the session and its index out of step — and
+    ``list_sessions`` handed the malformed rows back to its caller, which then
+    failed on ``.get``.  Rejecting them here routes both through the rebuild
+    path instead, which is the repair this index already has.
+    """
     return (
         isinstance(index, dict)
         and index.get("format_version") == 1
         and isinstance(index.get("sessions"), list)
+        and all(_is_valid_row(row) for row in index["sessions"])
     )
 
 
@@ -1485,7 +1561,14 @@ def complete_child_session(
         parent_item_id = child_session.get("parent_item_id")
         if parent_item_id is not None:
             parent_item = _require_item(parent_session, parent_item_id)
-            blocker = parent_item.get("blocker") or {}
+            # `blocker` is stored as a dict but nothing guarantees it stayed
+            # one — oboe_update_field sets any field to any value.  A bare
+            # `.get` on a string raised AttributeError *after* the child had
+            # already been written completed, leaving the parent paused with a
+            # dangling active_child_session and no tool able to clear it.
+            blocker = parent_item.get("blocker")
+            if not isinstance(blocker, dict):
+                blocker = {}
             if blocker.get("session_file") == child_session_file.name:
                 parent_item["status"] = "pending"
                 _clear_blocker_fields(parent_item)

--- a/src/oboe_mcp/session.py
+++ b/src/oboe_mcp/session.py
@@ -997,6 +997,38 @@ def session_status(session_file: Path) -> dict:
     }
 
 
+def _id_sort_key(item: dict) -> tuple[int, int, str]:
+    """Total order for item ids, which may be integers *or* strings.
+
+    ``id`` is documented as "string or integer", so one session can hold both
+    — and both `oboe_create` and `oboe_merge_items` accept whatever the caller
+    supplies.  Ordering on the raw value therefore raises
+    ``TypeError: '<' not supported between instances of 'int' and 'str'``.
+
+    The id is only ever a *tie-break* on ``priority_score``, which is what hid
+    this: a mixed-id session sorts fine until two of its items happen to score
+    the same, and then `oboe_next` and `oboe_list_items` both fail.
+
+    Numeric ids sort first, in numeric order; the rest follow as text.  A
+    string that spells a number is treated as that number, matching how
+    :func:`merge_items` already reads ``existing_ids`` when picking the next
+    integer id.
+    """
+    item_id = item.get("id", 0)
+    if isinstance(item_id, int) and not isinstance(item_id, bool):
+        return (0, item_id, "")
+    text = str(item_id)
+    try:
+        return (0, int(text), "")
+    except ValueError:
+        return (1, 0, text)
+
+
+def _priority_sort_key(item: dict) -> tuple[int, tuple[int, int, str]]:
+    """Highest priority_score first, lowest id as the tie-break."""
+    return (-item.get("priority_score", 0), _id_sort_key(item))
+
+
 def get_next(session_file: Path) -> dict | None:
     """Return the next item to work on.
 
@@ -1020,21 +1052,9 @@ def get_next(session_file: Path) -> dict | None:
     pending = [i for i in items if i.get("status") == "pending"]
     deferred = [i for i in items if i.get("status") == "deferred"]
 
-    if in_progress:
-        return sorted(
-            in_progress,
-            key=lambda x: (-x.get("priority_score", 0), x["id"]),
-        )[0]
-    if pending:
-        return sorted(
-            pending,
-            key=lambda x: (-x.get("priority_score", 0), x["id"]),
-        )[0]
-    if deferred:
-        return sorted(
-            deferred,
-            key=lambda x: (-x.get("priority_score", 0), x["id"]),
-        )[0]
+    for bucket in (in_progress, pending, deferred):
+        if bucket:
+            return sorted(bucket, key=_priority_sort_key)[0]
     return None
 
 
@@ -1048,10 +1068,7 @@ def list_items(
     items = session.get("items", [])
     if status_filter:
         items = [i for i in items if i.get("status") == status_filter]
-    return sorted(
-        items,
-        key=lambda x: (-x.get("priority_score", 0), x.get("id", 0)),
-    )
+    return sorted(items, key=_priority_sort_key)
 
 
 def get_item(session_file: Path, item_id: str | int) -> dict | None:

--- a/src/oboe_mcp/session.py
+++ b/src/oboe_mcp/session.py
@@ -16,6 +16,7 @@ import json
 import re
 from contextlib import contextmanager
 from datetime import datetime, timezone
+from math import isfinite
 from pathlib import Path
 
 from .locking import atomic_write_json, sessions_lock
@@ -34,7 +35,32 @@ _OPEN_ITEM_STATUSES = (
 _VALID_ITEM_STATUSES = _OPEN_ITEM_STATUSES | _TERMINAL_STATUSES
 _VALID_APPROVAL_STATUSES = {"unreviewed", "approved", "denied"}
 _VALID_APPROVAL_MODES = {"immediate", "delayed"}
-_SCORE_COMPONENTS = {"urgency", "importance", "effort", "dependencies"}
+# Ordered for deterministic error reporting; _SCORE_COMPONENTS stays a set
+# because the rest of the module uses it for membership tests only.
+_SCORE_COMPONENT_ORDER = ("urgency", "importance", "effort", "dependencies")
+_SCORE_COMPONENTS = set(_SCORE_COMPONENT_ORDER)
+_SCORE_MIN = 0
+_SCORE_MAX = 5
+# Fields `update_field` may set.  Deliberately an allow-list, not a denylist:
+# a session file is a documented schema, and an unrecognised field name is far
+# more likely a typo or a hallucinated field than a deliberate extension.
+# `id` is absent on purpose — see update_field.
+_UPDATABLE_FIELDS = {
+    "title",
+    "category",
+    "description",
+    "status",
+    "resolution",
+    "skip_reason",
+    "blocker",
+    "blocked_at",
+    "approval_status",
+    "approval_mode",
+    "approved_at",
+    "approval_note",
+    "child_session_resolution",
+    "priority_score",
+} | _SCORE_COMPONENTS
 _SESSION_RE = re.compile(r"^session_\d{8}_\d{6}\.json$")
 _VALID_SESSION_STATUSES = {"active", "paused", "completed", "cancelled"}
 
@@ -172,13 +198,245 @@ def _write_session_and_index(session_file: Path, session: dict) -> None:
 # Priority score
 # ---------------------------------------------------------------------------
 
+def _score_error(
+    item_id: object,
+    field: str,
+    value: object,
+    detail: str = "",
+) -> ValueError:
+    """Build the rejection message for a bad score component.
+
+    The message names the item *and* the field, because the caller supplies a
+    whole batch of items and the bare arithmetic error named neither.
+    """
+    suffix = detail or f"got {type(value).__name__}: {value!r}"
+    return ValueError(
+        f"item {item_id!r}: {field!r} must be a number "
+        f"{_SCORE_MIN}-{_SCORE_MAX} ({suffix})"
+    )
+
+
+def _as_score_int(value: object) -> int | None:
+    """Return *value* as an int if it is an integral real number, else None.
+
+    ``bool`` is rejected despite being an ``int`` subclass: ``True`` as an
+    urgency is a type error the caller wants to hear about, not a 1.  A float
+    is accepted only when integral, since JSON has no int/float distinction and
+    ``3.0`` is a legitimate way to write 3 — but ``2.5`` is not a score.
+    """
+    if isinstance(value, bool):
+        return None
+    if isinstance(value, int):
+        return int(value)
+    if isinstance(value, float):
+        if not isfinite(value) or not value.is_integer():
+            return None
+        return int(value)
+    return None
+
+
+def _score_value(item: dict, field: str, default: int) -> int:
+    """Read one score component for the arithmetic, or raise a clear error.
+
+    This is the *inner* of the two validation layers.  Boundary callers have
+    already validated their input via :func:`validate_score_components`; this
+    guard exists so that no route into the arithmetic — including loading a
+    session file written by an older version, or by hand — can produce a bare
+    ``TypeError`` naming neither item nor field.
+
+    It deliberately checks type only, not range: nothing has ever bounded these
+    values on disk, so enforcing the range here would make a previously
+    readable session file unloadable.
+    """
+    value = item.get(field, default)
+    number = _as_score_int(value)
+    if number is None:
+        raise _score_error(item.get("id"), field, value)
+    return number
+
+
+def validate_score_components(item: dict, item_id: object = None) -> dict:
+    """Validate and normalize caller-supplied score components, in place.
+
+    This is the *outer* layer, applied at the input boundary to items that
+    arrived from an MCP client, the CLI, or another caller — where the values
+    are LLM-generated JSON and cannot be assumed well-formed.  Unlike
+    :func:`_score_value` it also enforces the documented 0-5 range, and it
+    rejects a component that is present but ``None``.
+
+    Absent components are left absent; :func:`_normalize_item` supplies the
+    defaults.
+
+    Args:
+        item: Raw item dict; validated components are replaced with ints.
+        item_id: Identifier to name in errors. Defaults to ``item["id"]``.
+
+    Returns:
+        The same dict, for convenient chaining.
+
+    Raises:
+        ValueError: naming the item and the field, for any bad component.
+    """
+    if item_id is None:
+        item_id = item.get("id")
+    for field in _SCORE_COMPONENT_ORDER:
+        if field not in item:
+            continue
+        value = item[field]
+        number = _as_score_int(value)
+        if number is None:
+            raise _score_error(item_id, field, value)
+        if not _SCORE_MIN <= number <= _SCORE_MAX:
+            raise _score_error(item_id, field, value, detail=f"got {number}")
+        item[field] = number
+    return item
+
+
+def validate_item_id(item_id: object) -> str | int:
+    """Validate a caller-supplied item id.
+
+    ``id`` is documented as "string or integer".  Anything else reaches
+    :func:`_id_sort_key`, ``str()``-based lookup and the duplicate check as an
+    unconstrained value, so it is rejected at the boundary rather than stored.
+
+    ``None`` is rejected rather than silently read as "assign one for me":
+    ``setdefault`` does not replace an explicit ``None``, so it would have
+    become a real item id of ``None``, matched by the string ``"None"``.
+    """
+    if isinstance(item_id, bool) or item_id is None:
+        raise ValueError(
+            "Item 'id' must be a string or an integer "
+            f"(got {type(item_id).__name__}: {item_id!r}). "
+            "Omit the field entirely to have one assigned."
+        )
+    if isinstance(item_id, int):
+        return item_id
+    if isinstance(item_id, str):
+        if not item_id.strip():
+            raise ValueError("Item 'id' must not be blank")
+        return item_id
+    raise ValueError(
+        "Item 'id' must be a string or an integer "
+        f"(got {type(item_id).__name__}: {item_id!r})"
+    )
+
+
+def _stage_items(
+    items: list[dict],
+    taken: set[str] | None = None,
+    start: int = 1,
+) -> list[dict]:
+    """Validate a batch of caller-supplied items and settle their ids.
+
+    Runs before any lock is taken and before anything is written, so a batch
+    that fails validation leaves no session file, no directory and no
+    partially-appended items.
+
+    Explicit ids are validated and checked for duplicates — against each other
+    *and* against *taken*, the ids already in the session.  Items with no id
+    are assigned the lowest free integer, skipping ids the batch has claimed.
+
+    Both :func:`create_session` and :func:`merge_items` use this.  They used to
+    differ: ``merge_items`` rejected duplicates while ``create_session``
+    accepted them, and a duplicate id makes the second item permanently
+    unreachable — every lookup resolves to the first — so ``oboe_next`` could
+    hand back an item and then mark a *different* one in progress.
+
+    Args:
+        items: Raw item dicts from the caller.
+        taken: String forms of ids already present in the session.
+        start: Lowest integer to consider when auto-assigning. ``merge_items``
+            passes one past the highest existing id so an appended item never
+            reuses a number that already appeared in this session's history.
+
+    Returns:
+        Fresh copies, with score components normalized and ``id`` set.
+
+    Raises:
+        ValueError: for a bad score component, a bad id, or a duplicate id.
+    """
+    if not isinstance(items, list):
+        raise ValueError(
+            f"'items' must be a list of objects, got {type(items).__name__}"
+        )
+
+    claimed = set(taken or ())
+    staged: list[dict] = []
+
+    # First pass: validate everything the caller stated explicitly, so a
+    # duplicate is reported against the id the caller actually wrote.
+    for position, raw_item in enumerate(items, start=1):
+        # Check the container before copying it.  `dict(raw_item)` on a string
+        # or None reports in the interpreter's vocabulary ("dictionary update
+        # sequence element #0 has length 1") rather than saying which item of
+        # the batch is the wrong shape.
+        if not isinstance(raw_item, dict):
+            raise ValueError(
+                f"item #{position} must be an object, got "
+                f"{type(raw_item).__name__}: {raw_item!r}"
+            )
+        item = dict(raw_item)
+        if "id" in item:
+            item["id"] = validate_item_id(item["id"])
+            key = str(item["id"])
+            if key in claimed:
+                raise ValueError(f"Duplicate item id: {item['id']}")
+            claimed.add(key)
+        validate_score_components(item, item.get("id", f"#{position}"))
+        staged.append(item)
+
+    # Second pass: fill in the gaps.  Deferring this until every explicit id is
+    # known is what stops an auto-assigned id from colliding with one stated
+    # later in the same batch.
+    next_idx = start
+    for item in staged:
+        if "id" in item:
+            continue
+        while str(next_idx) in claimed:
+            next_idx += 1
+        item["id"] = next_idx
+        claimed.add(str(next_idx))
+        next_idx += 1
+
+    return staged
+
+
+def _validate_score_string(item_id: object, field: str, value: object) -> int:
+    """Validate a score component that arrived over a stringly-typed channel.
+
+    ``oboe_update_field`` declares ``value: str`` and the CLI reads it from
+    ``argv``, so a numeric string is the *normal* input there and is parsed
+    rather than rejected — unlike :func:`validate_score_components`, whose
+    callers receive JSON and can declare these fields as numbers.
+    """
+    candidate: object = value
+    if isinstance(value, str):
+        try:
+            candidate = int(value.strip())
+        except ValueError:
+            try:
+                candidate = float(value.strip())
+            except ValueError:
+                raise _score_error(item_id, field, value) from None
+    number = _as_score_int(candidate)
+    if number is None:
+        raise _score_error(item_id, field, value)
+    if not _SCORE_MIN <= number <= _SCORE_MAX:
+        raise _score_error(item_id, field, value, detail=f"got {number}")
+    return number
+
+
 def _recalc_priority(item: dict) -> int:
-    """Recalculate priority_score from component fields in place."""
+    """Recalculate priority_score from component fields in place.
+
+    Raises:
+        ValueError: if any component is non-numeric, naming item and field.
+    """
     item["priority_score"] = (
-        item.get("urgency", 3)
-        + item.get("importance", 3)
-        + (6 - item.get("effort", 3))
-        + item.get("dependencies", 1)
+        _score_value(item, "urgency", 3)
+        + _score_value(item, "importance", 3)
+        + (6 - _score_value(item, "effort", 3))
+        + _score_value(item, "dependencies", 1)
     )
     return item["priority_score"]
 
@@ -602,6 +860,10 @@ def create_session(
     """
     validate_session_filename(session_file.name)
 
+    # Validate before taking the lock or creating anything: a bad batch must
+    # not leave a directory or a half-written session behind.
+    staged = _stage_items(items)
+
     session_file.parent.mkdir(parents=True, exist_ok=True)
 
     with sessions_lock(session_file.parent, exclusive=True):
@@ -611,8 +873,7 @@ def create_session(
             )
 
         normalized = [
-            _normalize_item(dict(item), idx)
-            for idx, item in enumerate(items, start=1)
+            _normalize_item(item, item["id"]) for item in staged
         ]
 
         session = {
@@ -1170,22 +1431,19 @@ def merge_items(session_file: Path, items: list[dict]) -> dict:
         numeric_ids = [
             int(item_id) for item_id in existing_ids if item_id.isdigit()
         ]
-        next_idx = max(numeric_ids, default=0) + 1
-        merged_items = []
 
-        for raw_item in items:
-            item = dict(raw_item)
-            if "id" not in item:
-                while str(next_idx) in existing_ids:
-                    next_idx += 1
-                item["id"] = next_idx
-                next_idx += 1
-            if str(item["id"]) in existing_ids:
-                raise ValueError(f"Duplicate item id: {item['id']}")
+        # Validate and settle the whole batch first.  Raising here propagates
+        # out of session_transaction before its write, so a rejected merge
+        # appends nothing.
+        staged = _stage_items(
+            items, taken=existing_ids, start=max(numeric_ids, default=0) + 1
+        )
+
+        merged_items = []
+        for item in staged:
             normalized = _normalize_item(item, item["id"])
             session.setdefault("items", []).append(normalized)
             merged_items.append(normalized)
-            existing_ids.add(str(normalized["id"]))
 
         _sync_session_status(session)
     return {
@@ -1259,8 +1517,28 @@ def update_field(
 ) -> dict:
     """Update a field on an item, auto-recalculating priority_score if needed.
 
+    Only fields in the documented item schema may be set (see
+    ``_UPDATABLE_FIELDS``); the store is not a free-form bag.  ``id`` is
+    excluded outright — rewriting it into a collision makes an item permanently
+    unreachable, because every lookup then resolves to the other one.
+
     Returns the updated item dict.
+
+    Raises:
+        KeyError: no such item.
+        ValueError: unknown field, or a value the field rejects.
     """
+    if field not in _UPDATABLE_FIELDS:
+        if field == "id":
+            raise ValueError(
+                "'id' cannot be changed. An id collision makes one of the two "
+                "items unreachable, since every lookup resolves to the first."
+            )
+        raise ValueError(
+            f"Unknown item field: {field!r}. Updatable fields are: "
+            f"{', '.join(sorted(_UPDATABLE_FIELDS))}"
+        )
+
     with session_transaction(session_file) as session:
         item = _require_item(session, item_id)
         new_value: str | int | None = value
@@ -1295,10 +1573,18 @@ def update_field(
         }:
             if new_value in {"", "none", "null"}:
                 new_value = None
-        if field in _SCORE_COMPONENTS or field == "priority_score":
+        if field in _SCORE_COMPONENTS:
+            new_value = _validate_score_string(item_id, field, new_value)
+        elif field == "priority_score":
             if new_value is None:
                 raise ValueError(f"Field '{field}' cannot be null")
-            new_value = int(new_value)
+            try:
+                new_value = int(new_value)
+            except (TypeError, ValueError):
+                raise ValueError(
+                    f"item {item_id!r}: 'priority_score' must be a number "
+                    f"(got {type(new_value).__name__}: {new_value!r})"
+                ) from None
         item[field] = new_value
         if field in _SCORE_COMPONENTS:
             _recalc_priority(item)

--- a/src/oboe_mcp/session.py
+++ b/src/oboe_mcp/session.py
@@ -1202,6 +1202,48 @@ def cancel_session(session_file: Path, reason: str = "") -> dict:
     return session
 
 
+def _deletable_session(sessions_dir: Path, filename: str) -> Path:
+    """Resolve *filename* to a session file that is safe to delete.
+
+    ``trim_sessions`` decides what to remove from ``index.json``, and an index
+    row's ``file`` is not something this code wrote — it is whatever is on
+    disk, in a file that is routinely committed and synced between machines.
+    Joining it onto the sessions directory unchecked deleted a file *outside*
+    that directory: a planted row of ``../../IMPORTANT.txt`` was unlinked and
+    still reported as a deleted session.
+
+    Three independent checks, and a failure of any one is a refusal:
+
+    1. the name matches the documented ``session_YYYYMMDD_HHMMSS.json`` form,
+       which admits no separator and no ``..``;
+    2. it is a bare filename, with no directory part of its own;
+    3. the resolved path's parent is the resolved sessions directory — which
+       is what catches a symlink pointing out of the tree, something neither
+       name check can see.
+
+    Raises:
+        ValueError: naming the reason, if any check fails.
+    """
+    if not isinstance(filename, str) or not filename:
+        raise ValueError("index row has no usable 'file' name")
+
+    validate_session_filename(filename)   # (1)
+
+    candidate = Path(filename)
+    if candidate.name != filename or candidate.is_absolute():   # (2)
+        raise ValueError("must be a bare filename, not a path")
+
+    target = sessions_dir / filename
+    resolved_dir = sessions_dir.resolve()
+    # resolve() on the file itself follows a symlink to its destination, which
+    # is exactly the case check (3) exists to catch.
+    if target.resolve().parent != resolved_dir:   # (3)
+        raise ValueError(
+            f"resolves outside the sessions directory ({resolved_dir})"
+        )
+    return target
+
+
 def trim_sessions(
     sessions_dir: Path,
     before: datetime | str | None = None,
@@ -1221,8 +1263,10 @@ def trim_sessions(
             files.
 
     Returns:
-        A dict with keys ``deleted`` (list of filenames removed) and
-        ``retained`` (list of filenames kept), plus ``dry_run`` bool.
+        A dict with keys ``deleted`` (files actually removed — on a dry run,
+        those that would be), ``retained`` (files kept), and ``rejected``
+        (index rows naming something this function refuses to touch), plus
+        ``dry_run`` bool.
 
     Raises:
         ValueError: if *before* is not parseable as a datetime.
@@ -1247,6 +1291,13 @@ def trim_sessions(
         else:
             cutoff = before
 
+    # `created` is parsed from a bare YYYY-MM-DD and is therefore naive.  An
+    # ISO-8601 string carrying an offset — the most likely form for a machine
+    # to emit — produced an aware cutoff, and comparing the two raised
+    # TypeError from inside a delete operation.
+    if cutoff is not None and cutoff.tzinfo is not None:
+        cutoff = cutoff.astimezone().replace(tzinfo=None)
+
     # Deciding what to delete and deleting it must be one atomic step: the
     # decision is made from the index, and a concurrent mutation between the
     # two would shift the ground under it.
@@ -1254,6 +1305,8 @@ def trim_sessions(
         rows = list_sessions(sessions_dir)
         deleted: list[str] = []
         retained: list[str] = []
+        rejected: list[str] = []
+        targets: list[tuple[str, Path]] = []
 
         for row in rows:
             filename = row.get("file", "")
@@ -1276,15 +1329,26 @@ def trim_sessions(
                     retained.append(filename)
                     continue
 
-            deleted.append(filename)
+            try:
+                targets.append((filename, _deletable_session(
+                    sessions_dir, filename
+                )))
+            except ValueError as exc:
+                rejected.append(f"{filename!r}: {exc}")
 
-        if not dry_run:
-            for filename in deleted:
-                sf = sessions_dir / filename
+        if dry_run:
+            deleted = [name for name, _ in targets]
+        else:
+            for filename, path in targets:
                 try:
-                    sf.unlink(missing_ok=True)
-                except OSError:
-                    pass
+                    path.unlink()
+                except FileNotFoundError:
+                    # Already gone: the row was stale, not a deletion we did.
+                    continue
+                except OSError as exc:
+                    rejected.append(f"{filename!r}: {exc}")
+                    continue
+                deleted.append(filename)
             # Rebuild index from surviving files
             rebuilt = _rebuild_index_from_files(sessions_dir)
             _save_index(sessions_dir, rebuilt)
@@ -1292,9 +1356,11 @@ def trim_sessions(
     return {
         "deleted":  deleted,
         "retained": retained,
+        "rejected": rejected,
         "dry_run":  dry_run,
         "total_deleted":  len(deleted),
         "total_retained": len(retained),
+        "total_rejected": len(rejected),
     }
 
 

--- a/templates/agent-setup/copilot/prompts/obo.prompt.md
+++ b/templates/agent-setup/copilot/prompts/obo.prompt.md
@@ -22,7 +22,15 @@ Follow this workflow:
 1. Call `oboe_list_sessions` for the current workspace before extracting new items.
 2. If an incomplete session exists, ask whether to resume, merge, defer, replace, or stop.
 3. If creating a new session, extract discrete items from the current context.
-4. Assign priority factors for each item using urgency, importance, effort, and dependencies.
+4. Assign priority factors for each item. All four are **integers in the range 0-5**, never text:
+   - `urgency` (default 3) — how time-sensitive the item is.
+   - `importance` (default 3) — how much the item matters.
+   - `effort` (default 3) — how much work it is. Higher effort *lowers* the score.
+   - `dependencies` (default 1) — how much other work is waiting on this item, i.e. dependency **pressure**. This is **not** a description of what the item depends on; put that in `description`.
+
+   `priority_score = urgency + importance + (6 - effort) + dependencies`
+
+   A non-numeric or out-of-range factor is rejected with an error naming the item and the field, and nothing is written.
 5. Call `oboe_create` to persist the session. `items` is optional — if items are not yet known at session creation time, omit them and populate the session later with `oboe_merge_items`.
 6. If adding to an existing session, call `oboe_merge_items`.
 7. Present an executive summary before reviewing individual items. Include scope, item count, highest-impact items, important dependencies, and proposed order.

--- a/templates/agent-setup/copilot/skills/one-by-one/SKILL.md
+++ b/templates/agent-setup/copilot/skills/one-by-one/SKILL.md
@@ -50,7 +50,16 @@ If `oboe-mcp` is unavailable, stop and surface the blocker instead of silently f
 
 `priority_score = urgency + importance + (6 - effort) + dependencies`
 
-Defaults when not supplied: urgency=3, importance=3, effort=3, dependencies=1
+All four components are **integers in the range 0-5**. A non-numeric or
+out-of-range value is rejected with an error naming the item and the field;
+no session or item is written.
+
+| Component | Default | Meaning |
+| --- | --- | --- |
+| `urgency` | 3 | How time-sensitive the item is. Higher sorts first. |
+| `importance` | 3 | How much the item matters. Higher sorts first. |
+| `effort` | 3 | How much work it is. Higher effort *lowers* the score. |
+| `dependencies` | 1 | How much other work is waiting on this item — dependency **pressure**, as a number. **Not** a description of what the item depends on; that belongs in `description`. |
 
 ## Two State Axes
 

--- a/tests/test_cli_score_validation.py
+++ b/tests/test_cli_score_validation.py
@@ -1,0 +1,140 @@
+# Copyright (C) 2026 Gregory R. Warnes
+# SPDX-License-Identifier: AGPL-3.0-or-later
+#
+# This file is part of Oboe MCP.
+# For commercial licensing, contact greg@warnes-innovations.com
+
+"""CLI coverage for score-component validation (issue #20).
+
+``oboe-cli create``, ``merge``, ``create-child`` and ``update`` all reach the
+same score arithmetic as their MCP counterparts. Each must report a rejected
+component as a plain ``❌`` line with a non-zero exit status, not as an
+unhandled traceback: ``main()`` catches only ``FileNotFoundError`` and
+``LockError``, so anything a command does not catch escapes the process.
+"""
+
+import json
+
+import pytest
+
+from oboe_mcp.cli import main
+from oboe_mcp.session import create_session
+
+SCORE_COMPONENTS = ("urgency", "importance", "effort", "dependencies")
+
+BAD_ITEMS = [{
+    "id": "example",
+    "title": "Example item",
+    "dependencies": "Blocks the downstream cutover step",
+}]
+
+
+def _run(*args: str, expect_rc: int = 0) -> tuple[str, str]:
+    """Run oboe-cli main() and return (stdout, stderr)."""
+    from io import StringIO
+    import sys
+
+    old_out, old_err = sys.stdout, sys.stderr
+    sys.stdout = StringIO()
+    sys.stderr = StringIO()
+    rc: int = 0
+    try:
+        rc = main(list(args))
+    except SystemExit as exc:
+        rc = exc.code if isinstance(exc.code, int) else 1
+    finally:
+        out = sys.stdout.getvalue()
+        err = sys.stderr.getvalue()
+        sys.stdout, sys.stderr = old_out, old_err
+
+    assert rc == expect_rc, (
+        f"Expected rc={expect_rc}, got rc={rc}\nstdout: {out}\nstderr: {err}"
+    )
+    return out, err
+
+
+@pytest.fixture(name="base_dir")
+def fixture_base_dir(tmp_path):
+    (tmp_path / ".github" / "oboe_sessions").mkdir(parents=True)
+    return tmp_path
+
+
+@pytest.fixture(name="sessions_dir")
+def fixture_sessions_dir(base_dir):
+    return base_dir / ".github" / "oboe_sessions"
+
+
+@pytest.fixture(name="session_file")
+def fixture_session_file(sessions_dir):
+    sf = sessions_dir / "session_20260411_120000.json"
+    create_session(sf, [{"title": "Alpha"}], title="T", description="D")
+    return sf
+
+
+@pytest.fixture(name="bad_items_file")
+def fixture_bad_items_file(tmp_path):
+    p = tmp_path / "bad_items.json"
+    p.write_text(json.dumps(BAD_ITEMS))
+    return p
+
+
+def assert_clean_rejection(err: str, field: str) -> None:
+    assert "❌" in err, err
+    assert "unsupported operand" not in err, err
+    assert "Traceback" not in err, err
+    assert "example" in err, err
+    assert field in err, err
+
+
+def test_create_reports_bad_component_without_a_traceback(
+    base_dir, sessions_dir, bad_items_file
+):
+    """`create` caught only FileExistsError; a ValueError escaped main()."""
+    _, err = _run(
+        "--base-dir", str(base_dir), "create",
+        "--title", "Bad", "--input-file", str(bad_items_file),
+        expect_rc=1,
+    )
+    assert_clean_rejection(err, "dependencies")
+    assert list(sessions_dir.glob("session_*.json")) == []
+
+
+def test_merge_reports_bad_component(base_dir, session_file, bad_items_file):
+    _, err = _run(
+        "--base-dir", str(base_dir), "--session", session_file.name,
+        "merge", "--input-file", str(bad_items_file),
+        expect_rc=1,
+    )
+    assert_clean_rejection(err, "dependencies")
+
+
+def test_create_child_reports_bad_component(
+    base_dir, session_file, bad_items_file
+):
+    _, err = _run(
+        "--base-dir", str(base_dir), "--session", session_file.name,
+        "create-child", "--title", "Child",
+        "--input-file", str(bad_items_file),
+        expect_rc=1,
+    )
+    assert_clean_rejection(err, "dependencies")
+
+
+@pytest.mark.parametrize("field", SCORE_COMPONENTS)
+def test_update_reports_bad_component(base_dir, session_file, field):
+    _, err = _run(
+        "--base-dir", str(base_dir), "--session", session_file.name,
+        "update", "1", field, "Blocks the cutover",
+        expect_rc=1,
+    )
+    assert "❌" in err, err
+    assert "unsupported operand" not in err, err
+    assert field in err, err
+
+
+def test_update_still_accepts_a_numeric_string(base_dir, session_file):
+    out, _ = _run(
+        "--base-dir", str(base_dir), "--session", session_file.name,
+        "update", "1", "urgency", "1",
+    )
+    assert "priority_score recalculated" in out

--- a/tests/test_durability.py
+++ b/tests/test_durability.py
@@ -1,0 +1,211 @@
+# Copyright (C) 2026 Gregory R. Warnes
+# SPDX-License-Identifier: AGPL-3.0-or-later
+#
+# This file is part of Oboe MCP.
+# For commercial licensing, contact greg@warnes-innovations.com
+
+"""Writes must be atomic *and* durable, and a timeout must be a number.
+
+Three defects that were reachable only in the abstract, fixed anyway. A guard
+that today's caller cannot trip is still wrong code: the next caller — a test,
+another module, a future transport — is not bound by today's schema, and a
+crash is not bound by anything.
+"""
+
+import json
+import os
+
+import pytest
+
+from oboe_mcp.locking import (
+    DEFAULT_TIMEOUT,
+    LockPolicy,
+    _coerce_timeout,
+    atomic_write_json,
+    atomic_write_text,
+    get_default_policy,
+    set_default_policy,
+)
+from oboe_mcp.migrate import migrate_project
+from oboe_mcp.server import oboe_set_lock_policy
+
+
+@pytest.fixture(autouse=True)
+def _restore_lock_policy():
+    """set_default_policy mutates process state; put it back."""
+    before = get_default_policy()
+    yield
+    set_default_policy(blocking=before.blocking, timeout=before.timeout)
+
+
+# ---------------------------------------------------------------------------
+# Durability: the rename must be fsynced, not just performed
+# ---------------------------------------------------------------------------
+
+def _record_fsyncs(monkeypatch) -> list[int]:
+    """Capture every fd handed to os.fsync during a write."""
+    seen: list[int] = []
+    real = os.fsync
+
+    def spy(fd):
+        seen.append(fd)
+        return real(fd)
+
+    monkeypatch.setattr(os, "fsync", spy)
+    return seen
+
+
+def test_atomic_write_json_fsyncs_file_and_directory(tmp_path, monkeypatch):
+    """os.replace is atomic for readers; only fsyncing the dir is durable."""
+    seen = _record_fsyncs(monkeypatch)
+
+    atomic_write_json(tmp_path / "out.json", {"a": 1})
+
+    assert len(seen) == 2, (
+        f"expected an fsync of the file and of its directory, got {len(seen)}"
+    )
+    assert json.loads((tmp_path / "out.json").read_text()) == {"a": 1}
+
+
+def test_atomic_write_text_fsyncs_file_and_directory(tmp_path, monkeypatch):
+    seen = _record_fsyncs(monkeypatch)
+
+    atomic_write_text(tmp_path / "out.txt", "hello")
+
+    assert len(seen) == 2
+    assert (tmp_path / "out.txt").read_text() == "hello"
+
+
+def test_a_directory_fsync_failure_does_not_lose_the_write(
+    tmp_path, monkeypatch
+):
+    """Windows and some filesystems refuse it; the write already succeeded."""
+    real = os.fsync
+
+    def only_files(fd):
+        if os.fstat(fd).st_mode & 0o040000:  # S_IFDIR
+            raise OSError("directory fsync unsupported")
+        return real(fd)
+
+    monkeypatch.setattr(os, "fsync", only_files)
+
+    atomic_write_json(tmp_path / "out.json", {"a": 1})
+
+    assert json.loads((tmp_path / "out.json").read_text()) == {"a": 1}
+
+
+def test_atomic_write_leaves_no_temp_file_behind(tmp_path):
+    atomic_write_json(tmp_path / "out.json", {"a": 1})
+    atomic_write_text(tmp_path / "out.txt", "hi")
+    assert sorted(p.name for p in tmp_path.iterdir()) == ["out.json", "out.txt"]
+
+
+def test_atomic_write_failure_leaves_the_original_intact(tmp_path):
+    """A render that raises must not truncate what is already there."""
+    target = tmp_path / "out.json"
+    atomic_write_json(target, {"original": True})
+
+    class Unserializable:
+        pass
+
+    with pytest.raises(TypeError):
+        atomic_write_json(target, {"bad": Unserializable()})
+
+    assert json.loads(target.read_text()) == {"original": True}
+    assert [p.name for p in tmp_path.iterdir()] == ["out.json"]
+
+
+# ---------------------------------------------------------------------------
+# migrate rewrites the user's own files, and must not truncate in place
+# ---------------------------------------------------------------------------
+
+def test_migrate_rewrites_atomically(tmp_path, monkeypatch):
+    """`Path.write_text` truncates; a crash mid-write loses user content."""
+    github = tmp_path / ".github"
+    github.mkdir()
+    target = github / "copilot-instructions.md"
+    target.write_text("Use .github/obo_sessions/ for sessions.\n")
+
+    def no_truncating_writes(*_args, **_kwargs):
+        raise AssertionError("migrate must not truncate a file in place")
+
+    monkeypatch.setattr("pathlib.Path.write_text", no_truncating_writes)
+
+    result = migrate_project(tmp_path)
+
+    assert result.changed == [".github/copilot-instructions.md"]
+    assert "oboe_sessions" in target.read_text()
+    assert "obo_sessions" not in target.read_text()
+
+
+def test_migrate_preserves_file_mode(tmp_path):
+    """A temp file is created 0600; the destination's mode must survive."""
+    github = tmp_path / ".github"
+    github.mkdir()
+    target = github / "copilot-instructions.md"
+    target.write_text("Use .github/obo_sessions/ here.\n")
+    target.chmod(0o644)
+
+    migrate_project(tmp_path)
+
+    assert target.stat().st_mode & 0o777 == 0o644
+
+
+def test_migrate_leaves_no_temp_files(tmp_path):
+    github = tmp_path / ".github"
+    github.mkdir()
+    (github / "copilot-instructions.md").write_text(".github/obo_sessions/\n")
+
+    migrate_project(tmp_path)
+
+    assert [p.name for p in github.iterdir()] == ["copilot-instructions.md"]
+
+
+# ---------------------------------------------------------------------------
+# A lock timeout must be a number, whoever is calling
+# ---------------------------------------------------------------------------
+
+@pytest.mark.parametrize(
+    "bad", ["x", "30", True, False, [], {}, float("nan"), float("inf")]
+)
+def test_coerce_timeout_rejects_a_non_number(bad):
+    with pytest.raises(ValueError, match="[Ll]ock timeout"):
+        _coerce_timeout(bad)
+
+
+@pytest.mark.parametrize("good, expected", [(None, None), (5, 5.0), (2.5, 2.5)])
+def test_coerce_timeout_accepts_numbers_and_none(good, expected):
+    assert _coerce_timeout(good) == expected
+
+
+def test_set_default_policy_rejects_a_string_timeout():
+    """`timeout <= 0` against a string raised TypeError inside acquisition."""
+    with pytest.raises(ValueError, match="[Ll]ock timeout"):
+        set_default_policy(blocking=True, timeout="x")  # type: ignore[arg-type]
+    assert get_default_policy().timeout == DEFAULT_TIMEOUT
+
+
+def test_oboe_set_lock_policy_rejects_a_string_timeout():
+    result = oboe_set_lock_policy(blocking=True, timeout_seconds="x")  # type: ignore[arg-type]
+
+    assert result.startswith("ERROR: "), result
+    assert "internal error" not in result, (
+        "a bad argument is input rejection, not an internal defect"
+    )
+    assert "timeout" in result.lower()
+
+
+def test_oboe_set_lock_policy_still_accepts_valid_values():
+    assert json.loads(
+        oboe_set_lock_policy(blocking=True, timeout_seconds=5)
+    )["timeout_seconds"] == 5.0
+    # Zero or negative means "wait indefinitely".
+    assert json.loads(
+        oboe_set_lock_policy(blocking=True, timeout_seconds=0)
+    )["timeout_seconds"] is None
+
+
+def test_set_default_policy_normalises_blocking_to_a_bool():
+    assert set_default_policy(blocking=1, timeout=5) == LockPolicy(  # type: ignore[arg-type]
+        blocking=True, timeout=5.0
+    )

--- a/tests/test_error_boundaries.py
+++ b/tests/test_error_boundaries.py
@@ -1,0 +1,348 @@
+# Copyright (C) 2026 Gregory R. Warnes
+# SPDX-License-Identifier: AGPL-3.0-or-later
+#
+# This file is part of Oboe MCP.
+# For commercial licensing, contact greg@warnes-innovations.com
+
+"""Nothing from outside should surface as a raw interpreter error.
+
+A session file is hand-editable and synced between machines; an
+`index.json` row is not something this code wrote; and `blocker` is
+whatever `oboe_update_field` last set it to. Each of those reached code
+that assumed a shape, and the result was a `TypeError` or
+`AttributeError` with no indication of which file or field was wrong —
+one of them leaving a parent session permanently paused."""
+
+import json
+from pathlib import Path
+
+import pytest
+
+from oboe_mcp.cli import main
+from oboe_mcp.server import oboe_create, oboe_list_items
+from oboe_mcp.session import (
+    _is_valid_index,
+    complete_child_session,
+    create_child_session,
+    create_session,
+    get_item,
+    list_items,
+    list_sessions,
+    load_session,
+    mark_complete,
+    merge_items,
+    update_field,
+)
+
+
+def _run(*args: str, expect_rc: int = 0) -> tuple[str, str]:
+    """Run oboe-cli main() and return (stdout, stderr)."""
+    from io import StringIO
+    import sys
+
+    old_out, old_err = sys.stdout, sys.stderr
+    sys.stdout = StringIO()
+    sys.stderr = StringIO()
+    rc: int = 0
+    try:
+        rc = main(list(args))
+    except SystemExit as exc:
+        rc = exc.code if isinstance(exc.code, int) else 1
+    finally:
+        out = sys.stdout.getvalue()
+        err = sys.stderr.getvalue()
+        sys.stdout, sys.stderr = old_out, old_err
+
+    assert rc == expect_rc, (
+        f"Expected rc={expect_rc}, got rc={rc}\nstdout: {out}\nstderr: {err}"
+    )
+    return out, err
+
+
+@pytest.fixture(name="base_dir")
+def fixture_base_dir(tmp_path):
+    (tmp_path / ".github" / "oboe_sessions").mkdir(parents=True)
+    return tmp_path
+
+
+@pytest.fixture(name="sessions_dir")
+def fixture_sessions_dir(base_dir):
+    return base_dir / ".github" / "oboe_sessions"
+
+
+@pytest.fixture(name="session_file")
+def fixture_session_file(sessions_dir):
+    sf = sessions_dir / "session_20260411_120000.json"
+    create_session(
+        sf, [{"id": 1, "title": "Alpha"}], title="T", description="D"
+    )
+    return sf
+
+
+# ---------------------------------------------------------------------------
+# 2. complete_child_session must not wedge the parent
+# ---------------------------------------------------------------------------
+
+@pytest.fixture(name="paused_parent")
+def fixture_paused_parent(sessions_dir):
+    parent = sessions_dir / "session_20260411_120000.json"
+    child = sessions_dir / "session_20260411_130000.json"
+    create_session(
+        parent, [{"id": 1, "title": "P"}], title="T", description="D"
+    )
+    create_child_session(
+        parent, child, [{"id": 1, "title": "C"}],
+        title="child", description="d", parent_item_id=1,
+    )
+    mark_complete(child, 1, "done")
+    return parent, child
+
+
+def test_child_completion_survives_a_non_dict_blocker(paused_parent):
+    """oboe_update_field can set `blocker` to a string; `.get` then blew up."""
+    parent, child = paused_parent
+    update_field(parent, 1, "blocker", "just some text")
+
+    complete_child_session(child, "done")
+
+    session = load_session(parent)
+    assert session["active_child_session"] is None
+    assert session["status"] != "paused"
+
+
+def test_child_completion_still_unblocks_a_well_formed_blocker(paused_parent):
+    parent, child = paused_parent
+
+    complete_child_session(child, "resolved upstream")
+
+    item = get_item(parent, 1)
+    assert item is not None
+    assert item["status"] == "pending"
+    assert item["blocker"] is None
+    assert item["child_session_resolution"] == "resolved upstream"
+
+
+# ---------------------------------------------------------------------------
+# 5 & 6. A structurally-valid index carrying unusable rows
+# ---------------------------------------------------------------------------
+
+def _corrupt_rows(sessions_dir) -> None:
+    (sessions_dir / "index.json").write_text(
+        json.dumps({"format_version": 1, "sessions": ["oops", None, 42]})
+    )
+
+
+def test_is_valid_index_rejects_non_dict_rows():
+    bad_row = {"format_version": 1, "sessions": ["oops"]}
+    assert _is_valid_index(bad_row) is False
+    assert _is_valid_index({"format_version": 1, "sessions": [{}]}) is False
+    assert _is_valid_index(
+        {"format_version": 1, "sessions": [{"file": 7}]}
+    ) is False
+    assert _is_valid_index(
+        {"format_version": 1, "sessions": [{"file": "session_x.json"}]}
+    ) is True
+
+
+def test_merge_survives_an_index_with_unusable_rows(
+    session_file, sessions_dir
+):
+    """_upsert_index did `row["file"]` and raised TypeError after the write."""
+    _corrupt_rows(sessions_dir)
+
+    merge_items(session_file, [{"title": "Second"}])
+
+    index = json.loads((sessions_dir / "index.json").read_text())
+    assert _is_valid_index(index)
+    assert [r["file"] for r in index["sessions"]] == [session_file.name]
+
+
+def test_list_sessions_repairs_an_index_with_unusable_rows(
+    session_file, sessions_dir
+):
+    _corrupt_rows(sessions_dir)
+
+    rows = list_sessions(sessions_dir, status_filter="active")
+
+    assert [r["file"] for r in rows] == [session_file.name]
+
+
+def test_cli_sessions_survives_an_index_with_unusable_rows(
+    base_dir, session_file, sessions_dir
+):
+    _corrupt_rows(sessions_dir)
+    out, _ = _run("--base-dir", str(base_dir), "sessions")
+    assert session_file.name in out
+
+
+# ---------------------------------------------------------------------------
+# 9. A malformed session file reads as malformed, not as an interpreter error
+# ---------------------------------------------------------------------------
+
+MALFORMED = {
+    "items_not_a_list": ({"items": "oops"}, "'items' must be a list"),
+    "items_is_a_dict": ({"items": {"a": 1}}, "'items' must be a list"),
+    "item_is_a_string": ({"items": ["oops"]}, "item #1 must be an object"),
+    "item_is_null": ({"items": [None]}, "item #1 must be an object"),
+    "second_item_bad": (
+        {"items": [{"title": "ok"}, 7]}, "item #2 must be an object",
+    ),
+    "children_not_a_list": (
+        {"items": [], "child_session_files": "nope"},
+        "'child_session_files' must be a list",
+    ),
+}
+
+
+def _write_doc(sessions_dir, body) -> Path:
+    sf = sessions_dir / "session_20260411_120000.json"
+    if body is None:
+        sf.write_text(json.dumps([1, 2, 3]))
+    else:
+        sf.write_text(json.dumps({
+            "session_file": sf.name, "title": "t", "description": "",
+            "status": "active", "created": "2026-04-11", **body,
+        }))
+    return sf
+
+
+@pytest.mark.parametrize("case", sorted(MALFORMED))
+def test_malformed_session_names_the_file_and_the_problem(sessions_dir, case):
+    body, expected = MALFORMED[case]
+    sf = _write_doc(sessions_dir, body)
+
+    with pytest.raises(ValueError) as exc:
+        list_items(sf)
+
+    message = str(exc.value)
+    assert sf.name in message, message
+    assert expected in message, message
+
+
+@pytest.mark.parametrize(
+    "items, expected",
+    [
+        ("oops", "'items' must be a list"),
+        ({"a": 1}, "'items' must be a list"),
+        (["oops"], "item #1 must be an object"),
+        ([None], "item #1 must be an object"),
+        ([{"title": "ok"}, 7], "item #2 must be an object"),
+    ],
+)
+def test_a_malformed_items_argument_says_which_item(
+    sessions_dir, items, expected
+):
+    """The same check as for a file on disk, on the way in."""
+    sf = sessions_dir / "session_20260411_150000.json"
+    with pytest.raises(ValueError, match=expected):
+        create_session(sf, items, title="T", description="D")
+    assert not sf.exists()
+
+
+@pytest.mark.parametrize(
+    "items, expected",
+    [
+        ("oops", "'items' must be a list"),
+        ([None], "item #1 must be an object"),
+    ],
+)
+def test_oboe_create_rejects_a_malformed_items_argument(
+    base_dir, items, expected
+):
+    result = oboe_create(
+        base_dir=str(base_dir), title="T", description="D", items=items,
+        session_file="session_20260411_151000.json",
+    )
+    assert result.startswith("ERROR: "), result
+    assert expected in result
+    assert "internal error" not in result
+
+
+def test_malformed_top_level_document(sessions_dir):
+    sf = _write_doc(sessions_dir, None)
+    with pytest.raises(ValueError, match="expected a JSON object, got list"):
+        list_items(sf)
+
+
+@pytest.mark.parametrize("case", sorted(MALFORMED))
+def test_malformed_session_surfaces_as_a_tool_error(
+    base_dir, sessions_dir, case
+):
+    body, expected = MALFORMED[case]
+    sf = _write_doc(sessions_dir, body)
+
+    from oboe_mcp.server import oboe_list_items
+
+    result = oboe_list_items(session_file=sf.name, base_dir=str(base_dir))
+
+    assert result.startswith("ERROR: Malformed session file"), result
+    assert expected in result
+    assert "internal error" not in result, (
+        "a malformed file on disk is ordinary input, not an internal defect"
+    )
+
+
+@pytest.mark.parametrize("command", [["status"], ["list"], ["show", "1"]])
+def test_cli_reports_a_malformed_session_without_a_traceback(
+    base_dir, sessions_dir, command
+):
+    """main() caught only FileNotFoundError and LockError."""
+    sf = _write_doc(sessions_dir, {"items": "oops"})
+    _, err = _run(
+        "--base-dir", str(base_dir), "--session", sf.name, *command,
+        expect_rc=1,
+    )
+    assert "❌" in err
+    assert "Malformed session file" in err
+    assert "Traceback" not in err
+
+
+def test_a_malformed_session_does_not_break_listing_the_others(
+    base_dir, sessions_dir
+):
+    """One bad file must not hide every good one from `sessions`."""
+    good = sessions_dir / "session_20260411_130000.json"
+    create_session(good, [{"id": 1, "title": "Fine"}], title="Good",
+                   description="D")
+    _write_doc(sessions_dir, {"items": "oops"})
+    (sessions_dir / "index.json").unlink()
+
+    rows = {r["file"]: r["status"] for r in list_sessions(sessions_dir)}
+
+    assert rows[good.name] == "active"
+    assert rows["session_20260411_120000.json"] == "unreadable"
+
+
+# ---------------------------------------------------------------------------
+# 8. Nothing reaches the client as a raw interpreter error
+# ---------------------------------------------------------------------------
+
+def test_tool_boundary_labels_an_unexpected_exception(monkeypatch, base_dir):
+    """A defect must arrive as a labelled error, not a raw traceback."""
+    import oboe_mcp.server as server_module
+
+    def boom(*_args, **_kwargs):
+        raise AttributeError("'str' object has no attribute 'get'")
+
+    monkeypatch.setattr(server_module, "list_sessions", boom)
+    result = server_module.oboe_list_sessions(base_dir=str(base_dir))
+
+    assert result.startswith("ERROR: internal error in oboe_list_sessions")
+    assert "AttributeError" in result
+
+
+def test_tool_boundary_preserves_the_published_schema():
+    """The wrapper must not flatten the signature MCP clients rely on."""
+    import asyncio
+
+    from oboe_mcp.server import mcp
+
+    tools = {t.name: t for t in asyncio.run(mcp.list_tools())}
+    schema = tools["oboe_create"].input_schema["properties"]
+    assert set(schema) >= {
+        "base_dir", "title", "description", "items", "session_file",
+    }
+    assert "0-5" in schema["items"]["description"]
+    assert tools["oboe_create"].description.startswith(
+        "Create a new OBO session file"
+    )

--- a/tests/test_heterogeneous_keys.py
+++ b/tests/test_heterogeneous_keys.py
@@ -1,0 +1,189 @@
+# Copyright (C) 2026 Gregory R. Warnes
+# SPDX-License-Identifier: AGPL-3.0-or-later
+#
+# This file is part of Oboe MCP.
+# For commercial licensing, contact greg@warnes-innovations.com
+
+"""Regression tests for ordering caller-supplied values of mixed type.
+
+``id`` is documented as "string or integer" and ``category`` is free-form
+text, and both come straight from the caller. Sorting either one on its raw
+value raises ``TypeError: '<' not supported between instances of 'int' and
+'str'`` as soon as one session holds both types.
+
+Both are latent rather than obvious because the failing comparison is a
+*secondary* key: item ids are only compared when two items tie on
+``priority_score``, so a mixed-id session works right up until a tie appears.
+"""
+
+import json
+
+import pytest
+
+from oboe_mcp.cli import main
+from oboe_mcp.server import oboe_list_items, oboe_next, oboe_session_status
+from oboe_mcp.session import create_session, get_next, list_items
+
+# Both items score 3+3+(6-3)+1 = 10, so the id tie-break is always consulted.
+MIXED_ID_ITEMS = [
+    {"id": "phase-1", "title": "String id"},
+    {"id": 2, "title": "Integer id"},
+    {"id": "10", "title": "Numeric string id"},
+]
+
+
+def _run(*args: str, expect_rc: int = 0) -> tuple[str, str]:
+    from io import StringIO
+    import sys
+
+    old_out, old_err = sys.stdout, sys.stderr
+    sys.stdout = StringIO()
+    sys.stderr = StringIO()
+    rc: int = 0
+    try:
+        rc = main(list(args))
+    except SystemExit as exc:
+        rc = exc.code if isinstance(exc.code, int) else 1
+    finally:
+        out = sys.stdout.getvalue()
+        err = sys.stderr.getvalue()
+        sys.stdout, sys.stderr = old_out, old_err
+
+    assert rc == expect_rc, (
+        f"Expected rc={expect_rc}, got rc={rc}\nstdout: {out}\nstderr: {err}"
+    )
+    return out, err
+
+
+@pytest.fixture(name="base_dir")
+def fixture_base_dir(tmp_path):
+    (tmp_path / ".github" / "oboe_sessions").mkdir(parents=True)
+    return tmp_path
+
+
+@pytest.fixture(name="sessions_dir")
+def fixture_sessions_dir(base_dir):
+    return base_dir / ".github" / "oboe_sessions"
+
+
+@pytest.fixture(name="mixed_id_session")
+def fixture_mixed_id_session(sessions_dir):
+    sf = sessions_dir / "session_20260411_120000.json"
+    create_session(sf, MIXED_ID_ITEMS, title="Mixed", description="D")
+    return sf
+
+
+# ---------------------------------------------------------------------------
+# Item ids: string and integer in one session
+# ---------------------------------------------------------------------------
+
+def test_list_items_orders_mixed_ids(mixed_id_session):
+    ids = [i["id"] for i in list_items(mixed_id_session)]
+    # All three tie on score, so ordering is purely the id tie-break:
+    # numeric ids ascending first ("10" counts as 10), then text.
+    assert ids == [2, "10", "phase-1"]
+
+
+def test_get_next_picks_lowest_id_among_mixed(mixed_id_session):
+    item = get_next(mixed_id_session)
+    assert item is not None
+    assert item["id"] == 2
+
+
+def test_oboe_list_items_survives_mixed_ids(base_dir, mixed_id_session):
+    result = oboe_list_items(
+        session_file=mixed_id_session.name, base_dir=str(base_dir)
+    )
+    assert not result.startswith("ERROR: "), result
+    assert [i["id"] for i in json.loads(result)["items"]] == [
+        2, "10", "phase-1",
+    ]
+
+
+def test_oboe_next_survives_mixed_ids(base_dir, mixed_id_session):
+    result = oboe_next(
+        session_file=mixed_id_session.name, base_dir=str(base_dir)
+    )
+    assert not result.startswith("ERROR: "), result
+    # oboe_next returns the item dict itself, with progress spliced in.
+    assert json.loads(result)["id"] == 2
+
+
+def test_cli_list_and_next_survive_mixed_ids(base_dir, mixed_id_session):
+    out, _ = _run(
+        "--base-dir", str(base_dir), "--session", mixed_id_session.name,
+        "list",
+    )
+    assert "phase-1" in out
+    out, _ = _run(
+        "--base-dir", str(base_dir), "--session", mixed_id_session.name,
+        "next",
+    )
+    assert "NEXT ITEM (ID: 2)" in out
+
+
+def test_id_ordering_is_still_numeric_for_all_integer_ids(sessions_dir):
+    """The tie-break must not become lexicographic: 2 sorts before 10."""
+    sf = sessions_dir / "session_20260411_121000.json"
+    create_session(
+        sf,
+        [{"id": 10, "title": "Ten"}, {"id": 2, "title": "Two"}],
+        title="T", description="D",
+    )
+    assert [i["id"] for i in list_items(sf)] == [2, 10]
+
+
+def test_priority_still_outranks_id(sessions_dir):
+    """The id is a tie-break only; a higher score must still win."""
+    sf = sessions_dir / "session_20260411_122000.json"
+    create_session(
+        sf,
+        [
+            {"id": 1, "title": "Low", "urgency": 0},
+            {"id": "zzz", "title": "High", "urgency": 5},
+        ],
+        title="T", description="D",
+    )
+    assert [i["id"] for i in list_items(sf)] == ["zzz", 1]
+
+
+# ---------------------------------------------------------------------------
+# Categories: string and non-string in one session
+# ---------------------------------------------------------------------------
+
+def test_cli_status_survives_mixed_category_types(base_dir, sessions_dir):
+    """`category` is untyped: one session can hold 5 and 'General'."""
+    sf = sessions_dir / "session_20260411_130000.json"
+    create_session(
+        sf,
+        [
+            {"title": "A", "category": 5},
+            {"title": "B", "category": "General"},
+        ],
+        title="T", description="D",
+    )
+    out, _ = _run(
+        "--base-dir", str(base_dir), "--session", sf.name, "status",
+    )
+    assert "By Category" in out
+    assert "General" in out
+    assert "5" in out
+
+
+def test_oboe_session_status_survives_mixed_category_types(
+    base_dir, sessions_dir
+):
+    sf = sessions_dir / "session_20260411_131000.json"
+    create_session(
+        sf,
+        [
+            {"title": "A", "category": 5},
+            {"title": "B", "category": "General"},
+        ],
+        title="T", description="D",
+    )
+    result = oboe_session_status(
+        session_file=sf.name, base_dir=str(base_dir)
+    )
+    assert not result.startswith("ERROR: "), result
+    assert json.loads(result)["total"] == 2

--- a/tests/test_item_identity.py
+++ b/tests/test_item_identity.py
@@ -1,0 +1,221 @@
+# Copyright (C) 2026 Gregory R. Warnes
+# SPDX-License-Identifier: AGPL-3.0-or-later
+#
+# This file is part of Oboe MCP.
+# For commercial licensing, contact greg@warnes-innovations.com
+
+"""Item ids must be unique and addressable.
+
+`create_session` accepted duplicates where `merge_items` rejected them,
+and `update_field` could rewrite an id into a collision. A shadowed item
+is unreachable — every lookup resolves to the first — so it can never be
+completed and the session can never finish."""
+
+import json
+
+import pytest
+
+from oboe_mcp.cli import main
+from oboe_mcp.server import (
+    oboe_create,
+    oboe_merge_items,
+    oboe_next,
+    oboe_update_field,
+)
+from oboe_mcp.session import (
+    create_session,
+    get_item,
+    list_items,
+    merge_items,
+    update_field,
+    validate_item_id,
+)
+
+
+def _run(*args: str, expect_rc: int = 0) -> tuple[str, str]:
+    """Run oboe-cli main() and return (stdout, stderr)."""
+    from io import StringIO
+    import sys
+
+    old_out, old_err = sys.stdout, sys.stderr
+    sys.stdout = StringIO()
+    sys.stderr = StringIO()
+    rc: int = 0
+    try:
+        rc = main(list(args))
+    except SystemExit as exc:
+        rc = exc.code if isinstance(exc.code, int) else 1
+    finally:
+        out = sys.stdout.getvalue()
+        err = sys.stderr.getvalue()
+        sys.stdout, sys.stderr = old_out, old_err
+
+    assert rc == expect_rc, (
+        f"Expected rc={expect_rc}, got rc={rc}\nstdout: {out}\nstderr: {err}"
+    )
+    return out, err
+
+
+@pytest.fixture(name="base_dir")
+def fixture_base_dir(tmp_path):
+    (tmp_path / ".github" / "oboe_sessions").mkdir(parents=True)
+    return tmp_path
+
+
+@pytest.fixture(name="sessions_dir")
+def fixture_sessions_dir(base_dir):
+    return base_dir / ".github" / "oboe_sessions"
+
+
+@pytest.fixture(name="session_file")
+def fixture_session_file(sessions_dir):
+    sf = sessions_dir / "session_20260411_120000.json"
+    create_session(
+        sf, [{"id": 1, "title": "Alpha"}], title="T", description="D"
+    )
+    return sf
+
+
+# ---------------------------------------------------------------------------
+# 3 & 4. Item ids: duplicates, types, and rewrites
+# ---------------------------------------------------------------------------
+
+def test_create_rejects_duplicate_ids(sessions_dir):
+    """merge_items rejected these; create_session silently shadowed them."""
+    sf = sessions_dir / "session_20260411_140000.json"
+    with pytest.raises(ValueError, match="Duplicate item id"):
+        create_session(
+            sf,
+            [{"id": "x", "title": "First"}, {"id": "x", "title": "Second"}],
+            title="T", description="D",
+        )
+    assert not sf.exists()
+
+
+def test_oboe_create_rejects_duplicate_ids(base_dir):
+    result = oboe_create(
+        base_dir=str(base_dir), title="T", description="D",
+        items=[{"id": 1, "title": "A"}, {"id": 1, "title": "B"}],
+        session_file="session_20260411_140000.json",
+    )
+    assert result.startswith("ERROR: "), result
+    assert "Duplicate item id" in result
+
+
+def test_auto_ids_do_not_collide_with_a_later_explicit_id(sessions_dir):
+    """{} then {"id": 1} used to both become 1, shadowing the second."""
+    sf = sessions_dir / "session_20260411_141000.json"
+    create_session(
+        sf,
+        [{"title": "Auto"}, {"id": 1, "title": "Explicit"}],
+        title="T", description="D",
+    )
+    ids = sorted(str(i["id"]) for i in list_items(sf))
+    assert len(set(ids)) == 2, ids
+    titles = {str(i["id"]): i["title"] for i in list_items(sf)}
+    assert titles["1"] == "Explicit"
+
+
+def test_merge_still_rejects_a_duplicate_of_an_existing_id(session_file):
+    with pytest.raises(ValueError, match="Duplicate item id"):
+        merge_items(session_file, [{"id": 1, "title": "Clash"}])
+
+
+def test_merge_rejects_a_duplicate_within_its_own_batch(session_file):
+    with pytest.raises(ValueError, match="Duplicate item id"):
+        merge_items(
+            session_file,
+            [{"id": "new", "title": "A"}, {"id": "new", "title": "B"}],
+        )
+
+
+def test_merge_appends_beyond_the_highest_existing_id(session_file):
+    merge_items(session_file, [{"title": "Second"}])
+    assert sorted(i["id"] for i in list_items(session_file)) == [1, 2]
+
+
+def test_a_rejected_merge_appends_nothing(session_file):
+    before = session_file.read_bytes()
+    with pytest.raises(ValueError):
+        merge_items(
+            session_file,
+            [{"title": "Fine"}, {"id": 1, "title": "Clash"}],
+        )
+    assert session_file.read_bytes() == before
+
+
+@pytest.mark.parametrize("bad", [None, True, False, [], {}, 1.5, "  "])
+def test_create_rejects_a_bad_id_type(sessions_dir, bad):
+    sf = sessions_dir / "session_20260411_142000.json"
+    with pytest.raises(ValueError, match="id"):
+        create_session(sf, [{"id": bad, "title": "T"}], title="T",
+                       description="D")
+    assert not sf.exists()
+
+
+def test_validate_item_id_accepts_strings_and_integers():
+    assert validate_item_id(7) == 7
+    assert validate_item_id("phase-1") == "phase-1"
+
+
+def test_oboe_merge_items_rejects_a_null_id(base_dir, session_file):
+    result = oboe_merge_items(
+        session_file=session_file.name, base_dir=str(base_dir),
+        items=[{"id": None, "title": "T"}],
+    )
+    assert result.startswith("ERROR: "), result
+    assert "id" in result
+
+
+def test_update_field_refuses_to_change_id(session_file):
+    merge_items(session_file, [{"id": 2, "title": "B"}])
+    with pytest.raises(ValueError, match="'id' cannot be changed"):
+        update_field(session_file, 1, "id", 2)
+    assert sorted(i["id"] for i in list_items(session_file)) == [1, 2]
+
+
+def test_update_field_rejects_an_unknown_field(session_file):
+    with pytest.raises(ValueError, match="Unknown item field"):
+        update_field(session_file, 1, "totally_made_up", "x")
+    item = get_item(session_file, 1)
+    assert item is not None
+    assert "totally_made_up" not in item
+
+
+def test_oboe_update_field_rejects_an_unknown_field(base_dir, session_file):
+    result = oboe_update_field(
+        session_file=session_file.name, item_id="1",
+        field="totally_made_up", value="x", base_dir=str(base_dir),
+    )
+    assert result.startswith("ERROR: "), result
+    assert "Unknown item field" in result
+
+
+@pytest.mark.parametrize(
+    "field", ["title", "category", "description", "status", "resolution",
+              "urgency", "approval_note", "priority_score"],
+)
+def test_documented_fields_are_still_updatable(session_file, field):
+    values = {"status": "in_progress", "urgency": "4", "priority_score": "9"}
+    update_field(session_file, 1, field, values.get(field, "text"))
+
+
+def test_oboe_next_marks_the_item_it_returned(base_dir, sessions_dir):
+    """With duplicate ids this marked a different item than it handed back."""
+    sf = sessions_dir / "session_20260411_143000.json"
+    create_session(
+        sf,
+        [{"id": 1, "title": "A", "urgency": 5},
+         {"id": 2, "title": "B", "urgency": 1}],
+        title="T", description="D",
+    )
+    result = oboe_next(
+        session_file=sf.name, base_dir=str(base_dir), mark_in_progress=True
+    )
+    returned = json.loads(result)
+    in_progress = [
+        i["id"] for i in list_items(sf) if i["status"] == "in_progress"
+    ]
+    assert in_progress == [returned["id"]]
+
+

--- a/tests/test_score_validation.py
+++ b/tests/test_score_validation.py
@@ -1,0 +1,364 @@
+# Copyright (C) 2026 Gregory R. Warnes
+# SPDX-License-Identifier: AGPL-3.0-or-later
+#
+# This file is part of Oboe MCP.
+# For commercial licensing, contact greg@warnes-innovations.com
+
+"""Regression tests for score-component validation (issue #20).
+
+Passing a non-numeric ``dependencies`` (or any other score component) used to
+reach the ``priority_score`` arithmetic unchecked and raise an
+interpreter-level ``TypeError`` — ``unsupported operand type(s) for +: 'int'
+and 'str'`` — which names neither the offending item nor the offending field.
+
+Every entry point that accepts caller-supplied score components is covered
+here: ``create_session`` / ``oboe_create``, ``merge_items`` /
+``oboe_merge_items``, ``create_child_session`` /
+``oboe_create_child_session``, and ``update_field`` / ``oboe_update_field``.
+"""
+
+import json
+
+import pytest
+
+from oboe_mcp.server import (
+    oboe_create,
+    oboe_create_child_session,
+    oboe_merge_items,
+    oboe_update_field,
+)
+from oboe_mcp.session import (
+    _recalc_priority,
+    create_child_session,
+    create_session,
+    get_item,
+    merge_items,
+    update_field,
+)
+
+SCORE_COMPONENTS = ("urgency", "importance", "effort", "dependencies")
+
+# The exact payload from the issue report.
+REPORTED_ITEM = {
+    "id": "example",
+    "title": "Example item",
+    "description": "...",
+    "urgency": 3,
+    "importance": 4,
+    "effort": 2,
+    "dependencies": "Blocks the downstream cutover step",
+}
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+@pytest.fixture(name="sessions_dir")
+def fixture_sessions_dir(tmp_path):
+    d = tmp_path / ".github" / "oboe_sessions"
+    d.mkdir(parents=True)
+    return d
+
+
+@pytest.fixture(name="session_file")
+def fixture_session_file(sessions_dir):
+    sf = sessions_dir / "session_20260314_120000.json"
+    create_session(sf, [{"title": "Alpha"}], title="T", description="D")
+    return sf
+
+
+@pytest.fixture(name="base_dir")
+def fixture_base_dir(tmp_path):
+    return str(tmp_path)
+
+
+@pytest.fixture(name="session_name")
+def fixture_session_name(base_dir):
+    result = oboe_create(
+        base_dir=base_dir,
+        title="Test Session",
+        description="d",
+        items=[{"title": "Alpha"}],
+        session_file="session_20260314_120000.json",
+    )
+    return json.loads(result)["session_file"]
+
+
+def assert_names_item_and_field(
+    message: str, item_id: object, field: str
+) -> None:
+    """The error must identify *which* item and *which* field was rejected."""
+    assert "unsupported operand" not in message, (
+        "raw TypeError surfaced instead of a validation error"
+    )
+    assert repr(item_id) in message or str(item_id) in message, message
+    assert field in message, message
+
+
+# ---------------------------------------------------------------------------
+# Layer 1 — create_session / oboe_create (the exact reported failure)
+# ---------------------------------------------------------------------------
+
+def test_create_session_rejects_string_dependencies(sessions_dir):
+    """The reproduction from issue #20, at the session-logic layer."""
+    sf = sessions_dir / "session_20260314_121000.json"
+    with pytest.raises(ValueError) as exc:
+        create_session(sf, [dict(REPORTED_ITEM)], title="T", description="D")
+
+    assert_names_item_and_field(str(exc.value), "example", "dependencies")
+    assert not sf.exists(), "a rejected session must not be written to disk"
+
+
+def test_oboe_create_rejects_string_dependencies(base_dir):
+    """The reproduction from issue #20, at the MCP tool boundary."""
+    result = oboe_create(
+        base_dir=base_dir,
+        title="My Session",
+        description="desc",
+        items=[dict(REPORTED_ITEM)],
+        session_file="session_20260314_130000.json",
+    )
+    assert result.startswith("ERROR: "), result
+    assert_names_item_and_field(result, "example", "dependencies")
+
+
+@pytest.mark.parametrize("field", SCORE_COMPONENTS)
+def test_create_session_rejects_string_in_any_component(sessions_dir, field):
+    sf = sessions_dir / "session_20260314_122000.json"
+    item = {"id": "example", "title": "T", field: "not a number"}
+    with pytest.raises(ValueError) as exc:
+        create_session(sf, [item], title="T", description="D")
+    assert_names_item_and_field(str(exc.value), "example", field)
+
+
+@pytest.mark.parametrize(
+    "value", [None, True, False, [], {}, "3", "", 2.5, float("nan")]
+)
+def test_create_session_rejects_non_integer_values(sessions_dir, value):
+    """Booleans, containers, numeric *strings* and fractions are all rejected.
+
+    Numeric strings are rejected here deliberately: the ``oboe_create`` schema
+    declares these fields as JSON numbers, and silently coercing ``"3"`` is the
+    quiet-default behaviour this issue asks us not to have.
+    """
+    sf = sessions_dir / "session_20260314_123000.json"
+    item = {"id": "example", "title": "T", "dependencies": value}
+    with pytest.raises(ValueError) as exc:
+        create_session(sf, [item], title="T", description="D")
+    assert_names_item_and_field(str(exc.value), "example", "dependencies")
+
+
+def test_create_session_rejects_out_of_range(sessions_dir):
+    sf = sessions_dir / "session_20260314_124000.json"
+    item = {"id": "example", "title": "T", "urgency": 42}
+    with pytest.raises(ValueError) as exc:
+        create_session(sf, [item], title="T", description="D")
+    assert_names_item_and_field(str(exc.value), "example", "urgency")
+
+
+def test_create_session_reports_the_offending_item_not_the_first(sessions_dir):
+    """A bad item in the middle of a batch is named, not item 1."""
+    sf = sessions_dir / "session_20260314_125000.json"
+    items = [
+        {"title": "Good"},
+        {"id": "bad-one", "title": "Bad", "dependencies": "lots"},
+        {"title": "Also good"},
+    ]
+    with pytest.raises(ValueError) as exc:
+        create_session(sf, items, title="T", description="D")
+    assert_names_item_and_field(str(exc.value), "bad-one", "dependencies")
+
+
+def test_create_session_accepts_valid_scores(sessions_dir):
+    sf = sessions_dir / "session_20260314_126000.json"
+    session = create_session(
+        sf,
+        [{
+            "title": "Fine",
+            "urgency": 5,
+            "importance": 4,
+            "effort": 2,
+            "dependencies": 3,
+        }],
+        title="T",
+        description="D",
+    )
+    assert session["items"][0]["priority_score"] == 5 + 4 + (6 - 2) + 3
+
+
+def test_create_session_accepts_integral_floats(sessions_dir):
+    """JSON has no int/float distinction; ``3.0`` is a valid integer score."""
+    sf = sessions_dir / "session_20260314_127000.json"
+    session = create_session(
+        sf,
+        [{"title": "Fine", "urgency": 5.0, "dependencies": 0}],
+        title="T",
+        description="D",
+    )
+    item = session["items"][0]
+    assert item["urgency"] == 5
+    assert isinstance(item["urgency"], int)
+    assert item["priority_score"] == 5 + 3 + (6 - 3) + 0
+
+
+# ---------------------------------------------------------------------------
+# Bug-class siblings — merge_items / oboe_merge_items
+# ---------------------------------------------------------------------------
+
+def test_merge_items_rejects_string_dependencies(session_file):
+    with pytest.raises(ValueError) as exc:
+        merge_items(session_file, [dict(REPORTED_ITEM)])
+    assert_names_item_and_field(str(exc.value), "example", "dependencies")
+
+
+def test_merge_items_rejection_leaves_session_unchanged(session_file):
+    before = session_file.read_bytes()
+    with pytest.raises(ValueError):
+        merge_items(session_file, [dict(REPORTED_ITEM)])
+    assert session_file.read_bytes() == before
+
+
+def test_oboe_merge_items_rejects_string_dependencies(base_dir, session_name):
+    result = oboe_merge_items(
+        session_file=session_name,
+        items=[dict(REPORTED_ITEM)],
+        base_dir=base_dir,
+    )
+    assert result.startswith("ERROR: "), result
+    assert_names_item_and_field(result, "example", "dependencies")
+
+
+@pytest.mark.parametrize("field", SCORE_COMPONENTS)
+def test_merge_items_rejects_string_in_any_component(session_file, field):
+    item = {"id": "example", "title": "T", field: "not a number"}
+    with pytest.raises(ValueError) as exc:
+        merge_items(session_file, [item])
+    assert_names_item_and_field(str(exc.value), "example", field)
+
+
+# ---------------------------------------------------------------------------
+# Bug-class siblings — create_child_session / oboe_create_child_session
+# ---------------------------------------------------------------------------
+
+def test_create_child_session_rejects_string_dependencies(
+    sessions_dir, session_file
+):
+    child_sf = sessions_dir / "session_20260314_140000.json"
+    with pytest.raises(ValueError) as exc:
+        create_child_session(
+            session_file,
+            child_sf,
+            [dict(REPORTED_ITEM)],
+            title="Child",
+            description="d",
+        )
+    assert_names_item_and_field(str(exc.value), "example", "dependencies")
+    assert not child_sf.exists()
+
+
+def test_oboe_create_child_session_rejects_string_dependencies(
+    base_dir, session_name
+):
+    result = oboe_create_child_session(
+        parent_session_file=session_name,
+        title="Child",
+        description="d",
+        items=[dict(REPORTED_ITEM)],
+        base_dir=base_dir,
+        session_file="session_20260314_165000.json",
+    )
+    assert result.startswith("ERROR: "), result
+    assert_names_item_and_field(result, "example", "dependencies")
+
+
+# ---------------------------------------------------------------------------
+# Bug-class siblings — update_field / oboe_update_field
+# ---------------------------------------------------------------------------
+
+@pytest.mark.parametrize("field", SCORE_COMPONENTS)
+def test_update_field_rejects_non_numeric(session_file, field):
+    with pytest.raises(ValueError) as exc:
+        update_field(session_file, 1, field, "Blocks the cutover")
+    assert_names_item_and_field(str(exc.value), 1, field)
+
+
+def test_update_field_rejects_out_of_range(session_file):
+    with pytest.raises(ValueError) as exc:
+        update_field(session_file, 1, "dependencies", "9")
+    assert_names_item_and_field(str(exc.value), 1, "dependencies")
+
+
+def test_update_field_rejects_null_score(session_file):
+    with pytest.raises(ValueError) as exc:
+        bad: object = None
+        update_field(session_file, 1, "urgency", bad)  # type: ignore[arg-type]
+    assert_names_item_and_field(str(exc.value), 1, "urgency")
+
+
+def test_update_field_still_accepts_numeric_strings(session_file):
+    """The CLI and the MCP tool both hand ``value`` over as a string."""
+    item = update_field(session_file, 1, "urgency", "1")
+    assert item["urgency"] == 1
+    assert item["priority_score"] == 1 + 3 + (6 - 3) + 1
+
+
+def test_update_field_rejection_leaves_item_unchanged(session_file):
+    before = get_item(session_file, 1)
+    with pytest.raises(ValueError):
+        update_field(session_file, 1, "dependencies", "many")
+    assert get_item(session_file, 1) == before
+
+
+def test_oboe_update_field_rejects_non_numeric(base_dir, session_name):
+    result = oboe_update_field(
+        session_file=session_name,
+        item_id="1",
+        field="dependencies",
+        value="Blocks the downstream cutover step",
+        base_dir=base_dir,
+    )
+    assert result.startswith("ERROR: "), result
+    assert_names_item_and_field(result, "1", "dependencies")
+
+
+# ---------------------------------------------------------------------------
+# Layer 2 (defence in depth) — the arithmetic itself never sees a bad value
+# ---------------------------------------------------------------------------
+
+@pytest.mark.parametrize("field", SCORE_COMPONENTS)
+def test_recalc_priority_raises_valueerror_not_typeerror(field):
+    """Whatever route a bad value takes, the arithmetic must not TypeError."""
+    item = {"id": "example", field: "not a number"}
+    with pytest.raises(ValueError) as exc:
+        _recalc_priority(item)
+    assert_names_item_and_field(str(exc.value), "example", field)
+
+
+def test_recalc_priority_tolerates_out_of_range_legacy_values():
+    """Range is enforced on new input only — old files must still load.
+
+    Nothing ever bounded these values on disk, so applying the range check to
+    the normalisation path would make a previously-readable session file
+    unloadable.  Type is still enforced; the range is not.
+    """
+    item = {"id": "legacy", "urgency": 42, "importance": 3,
+            "effort": 3, "dependencies": 1}
+    assert _recalc_priority(item) == 42 + 3 + (6 - 3) + 1
+
+
+def test_session_with_out_of_range_scores_still_loads(sessions_dir):
+    """End-to-end version of the above, through the real load path."""
+    sf = sessions_dir / "session_20260314_150000.json"
+    sf.write_text(json.dumps({
+        "session_file": sf.name,
+        "created": "2026-03-14T15:00:00",
+        "title": "Legacy",
+        "description": "",
+        "status": "active",
+        "items": [{"id": 1, "title": "Old", "urgency": 42,
+                   "importance": 3, "effort": 3, "dependencies": 1}],
+    }))
+    item = get_item(sf, 1)
+    assert item is not None
+    assert item["priority_score"] == 42 + 3 + (6 - 3) + 1

--- a/tests/test_tool_schema.py
+++ b/tests/test_tool_schema.py
@@ -1,0 +1,88 @@
+# Copyright (C) 2026 Gregory R. Warnes
+# SPDX-License-Identifier: AGPL-3.0-or-later
+#
+# This file is part of Oboe MCP.
+# For commercial licensing, contact greg@warnes-innovations.com
+
+"""Tests for the published MCP tool schemas (issue #20, layer 2).
+
+Layer 1 stops a bad ``dependencies`` from crashing the server. Layer 2 is what
+stops the caller from sending one: the tool schema and description have to say
+that the four priority factors are numbers. These tests assert the contract is
+actually *published*, not merely intended — a docstring edit that never
+reaches the wire is exactly the failure mode this layer exists to prevent.
+"""
+
+import asyncio
+
+import pytest
+
+from oboe_mcp.server import mcp
+
+SCORE_COMPONENTS = ("urgency", "importance", "effort", "dependencies")
+ITEM_TOOLS = ("oboe_create", "oboe_merge_items", "oboe_create_child_session")
+
+
+@pytest.fixture(scope="module", name="tools")
+def fixture_tools():
+    return {t.name: t for t in asyncio.run(mcp.list_tools())}
+
+
+def _items_schema(tool) -> dict:
+    """Return the schema describing one element of the ``items`` array."""
+    param = tool.input_schema["properties"]["items"]
+    if "items" in param:
+        return param["items"]
+    for branch in param.get("anyOf", []):
+        if branch.get("type") == "array":
+            return branch["items"]
+    raise AssertionError(f"no array schema for items on {tool.name}")
+
+
+@pytest.mark.parametrize("tool_name", ITEM_TOOLS)
+@pytest.mark.parametrize("field", SCORE_COMPONENTS)
+def test_score_fields_published_as_bounded_numbers(tools, tool_name, field):
+    prop = _items_schema(tools[tool_name])["properties"][field]
+    assert prop["type"] == "number"
+    assert prop["minimum"] == 0
+    assert prop["maximum"] == 5
+    assert "0-5" in prop["description"]
+
+
+@pytest.mark.parametrize("tool_name", ITEM_TOOLS)
+def test_dependencies_description_disclaims_the_obvious_misreading(
+    tools, tool_name
+):
+    """The field name invites 'what this item depends on'. Say it is not."""
+    desc = _items_schema(tools[tool_name])["properties"]["dependencies"]
+    text = desc["description"].lower()
+    assert "not a description" in text
+    assert "pressure" in text
+
+
+@pytest.mark.parametrize("tool_name", ITEM_TOOLS)
+def test_items_parameter_description_states_the_numeric_contract(
+    tools, tool_name
+):
+    param = tools[tool_name].input_schema["properties"]["items"]
+    assert "0-5" in param["description"]
+    assert "dependencies" in param["description"]
+
+
+@pytest.mark.parametrize("tool_name", ITEM_TOOLS)
+def test_item_schema_still_allows_unlisted_fields(tools, tool_name):
+    """Callers pass fields we do not enumerate; do not make them invalid."""
+    assert _items_schema(tools[tool_name])["additionalProperties"] is True
+
+
+def test_oboe_create_description_states_the_numeric_contract(tools):
+    text = tools["oboe_create"].description
+    assert "0-5" in text
+    for field in SCORE_COMPONENTS:
+        assert field in text
+
+
+def test_oboe_update_field_description_states_the_numeric_contract(tools):
+    text = tools["oboe_update_field"].description
+    assert "0-5" in text
+    assert "dependencies" in text

--- a/tests/test_trim_safety.py
+++ b/tests/test_trim_safety.py
@@ -1,0 +1,237 @@
+# Copyright (C) 2026 Gregory R. Warnes
+# SPDX-License-Identifier: AGPL-3.0-or-later
+#
+# This file is part of Oboe MCP.
+# For commercial licensing, contact greg@warnes-innovations.com
+
+"""`trim_sessions` deletes files, and decides what to delete from
+`index.json` — a file this code did not write, that is routinely
+committed and synced between machines. A planted row of
+`../../IMPORTANT.txt` was unlinked and still reported as a deleted
+session.
+
+Every case here was reproduced against the unfixed code first."""
+
+import json
+from datetime import datetime, timedelta, timezone
+
+import pytest
+
+from oboe_mcp.cli import main
+from oboe_mcp.server import oboe_trim_sessions
+from oboe_mcp.session import (
+    _deletable_session,
+    create_session,
+    mark_complete,
+    trim_sessions,
+)
+
+
+def _run(*args: str, expect_rc: int = 0) -> tuple[str, str]:
+    """Run oboe-cli main() and return (stdout, stderr)."""
+    from io import StringIO
+    import sys
+
+    old_out, old_err = sys.stdout, sys.stderr
+    sys.stdout = StringIO()
+    sys.stderr = StringIO()
+    rc: int = 0
+    try:
+        rc = main(list(args))
+    except SystemExit as exc:
+        rc = exc.code if isinstance(exc.code, int) else 1
+    finally:
+        out = sys.stdout.getvalue()
+        err = sys.stderr.getvalue()
+        sys.stdout, sys.stderr = old_out, old_err
+
+    assert rc == expect_rc, (
+        f"Expected rc={expect_rc}, got rc={rc}\nstdout: {out}\nstderr: {err}"
+    )
+    return out, err
+
+
+@pytest.fixture(name="base_dir")
+def fixture_base_dir(tmp_path):
+    (tmp_path / ".github" / "oboe_sessions").mkdir(parents=True)
+    return tmp_path
+
+
+@pytest.fixture(name="sessions_dir")
+def fixture_sessions_dir(base_dir):
+    return base_dir / ".github" / "oboe_sessions"
+
+
+@pytest.fixture(name="session_file")
+def fixture_session_file(sessions_dir):
+    sf = sessions_dir / "session_20260411_120000.json"
+    create_session(
+        sf, [{"id": 1, "title": "Alpha"}], title="T", description="D"
+    )
+    return sf
+
+
+# ---------------------------------------------------------------------------
+# 1. trim_sessions must not delete outside the sessions directory
+# ---------------------------------------------------------------------------
+
+def _plant_row(sessions_dir, **row) -> None:
+    """Append a row to index.json, as a hand-edit or a bad sync would."""
+    path = sessions_dir / "index.json"
+    idx = (
+        json.loads(path.read_text())
+        if path.exists()
+        else {"format_version": 1, "last_updated": "", "sessions": []}
+    )
+    idx["sessions"].append(
+        {"status": "completed", "created": "2026-01-01", **row}
+    )
+    path.write_text(json.dumps(idx))
+
+
+def test_trim_refuses_a_traversing_index_row(base_dir, sessions_dir):
+    """A row of '../../X' unlinked a real file outside the tree."""
+    victim = base_dir / "IMPORTANT.txt"
+    victim.write_text("user data")
+    sf = sessions_dir / "session_20260411_120000.json"
+    create_session(sf, [{"id": 1, "title": "A"}], title="T", description="D")
+    mark_complete(sf, 1, "done")
+    _plant_row(sessions_dir, file="../../IMPORTANT.txt")
+
+    result = trim_sessions(
+        sessions_dir, before="now", status_filter="completed"
+    )
+
+    assert victim.exists(), "deleted a file outside the sessions directory"
+    assert victim.read_text() == "user data"
+    assert "../../IMPORTANT.txt" not in result["deleted"]
+    assert any("IMPORTANT" in note for note in result["rejected"])
+
+
+def test_trim_refuses_an_absolute_index_row(base_dir, sessions_dir):
+    victim = base_dir / "ABSOLUTE.txt"
+    victim.write_text("user data")
+    _plant_row(sessions_dir, file=str(victim))
+
+    result = trim_sessions(
+        sessions_dir, before="now", status_filter="completed"
+    )
+
+    assert victim.exists()
+    assert result["rejected"]
+
+
+def test_trim_refuses_a_symlink_out_of_the_tree(base_dir, sessions_dir):
+    """Name checks cannot see a symlink; the containment check can."""
+    victim = base_dir / "LINKED.txt"
+    victim.write_text("user data")
+    link = sessions_dir / "session_20260101_000000.json"
+    link.symlink_to(victim)
+    _plant_row(sessions_dir, file=link.name)
+
+    result = trim_sessions(
+        sessions_dir, before="now", status_filter="completed"
+    )
+
+    assert victim.exists(), "followed a symlink out of the sessions directory"
+    assert result["rejected"]
+
+
+def test_trim_does_not_report_a_row_with_no_file_as_deleted(sessions_dir):
+    """'' joined to the directory itself, and was still counted as deleted."""
+    _plant_row(sessions_dir, title="no file key")
+
+    result = trim_sessions(
+        sessions_dir, before="now", status_filter="completed"
+    )
+
+    assert "" not in result["deleted"]
+    assert sessions_dir.is_dir()
+
+
+def test_trim_deleted_list_reflects_what_was_actually_removed(sessions_dir):
+    sf = sessions_dir / "session_20260411_120000.json"
+    create_session(sf, [{"id": 1, "title": "A"}], title="T", description="D")
+    mark_complete(sf, 1, "done")
+
+    result = trim_sessions(
+        sessions_dir, before="now", status_filter="completed"
+    )
+
+    assert result["deleted"] == [sf.name]
+    assert not sf.exists()
+
+
+def test_trim_dry_run_touches_nothing(sessions_dir):
+    sf = sessions_dir / "session_20260411_120000.json"
+    create_session(sf, [{"id": 1, "title": "A"}], title="T", description="D")
+    mark_complete(sf, 1, "done")
+
+    result = trim_sessions(
+        sessions_dir, before="now", status_filter="completed", dry_run=True
+    )
+
+    assert result["deleted"] == [sf.name]
+    assert sf.exists()
+
+
+def test_cli_trim_reports_refused_rows(base_dir, sessions_dir):
+    victim = base_dir / "IMPORTANT.txt"
+    victim.write_text("user data")
+    _plant_row(sessions_dir, file="../../IMPORTANT.txt")
+
+    _, err = _run(
+        "--base-dir", str(base_dir), "trim-sessions", "--before", "now",
+    )
+    assert "Refused" in err
+    assert "IMPORTANT" in err
+    assert victim.exists()
+
+
+@pytest.mark.parametrize(
+    "name",
+    ["", "../evil.json", "sub/session_20260411_120000.json",
+     "/etc/passwd", "notes.txt", "session_bad.json"],
+)
+def test_deletable_session_rejects(sessions_dir, name):
+    with pytest.raises(ValueError):
+        _deletable_session(sessions_dir, name)
+
+
+def test_deletable_session_accepts_a_real_session_name(sessions_dir):
+    target = _deletable_session(sessions_dir, "session_20260411_120000.json")
+    assert target.parent == sessions_dir
+
+
+# ---------------------------------------------------------------------------
+# 7. trim_sessions and an offset-aware `before`
+# ---------------------------------------------------------------------------
+
+def test_trim_accepts_a_timezone_aware_before(base_dir, sessions_dir):
+    """An ISO-8601 string with an offset raised TypeError mid-delete."""
+    sf = sessions_dir / "session_20260411_120000.json"
+    create_session(sf, [{"id": 1, "title": "A"}], title="T", description="D")
+    mark_complete(sf, 1, "done")
+    future = (datetime.now(timezone.utc) + timedelta(days=1)).isoformat()
+
+    result = trim_sessions(
+        sessions_dir, before=future, status_filter="completed", dry_run=True
+    )
+    assert result["deleted"] == [sf.name]
+
+
+def test_oboe_trim_accepts_a_timezone_aware_before(base_dir, sessions_dir):
+    # A completed session must exist, or the age comparison never runs and
+    # the test cannot see the failure it exists to catch.
+    sf = sessions_dir / "session_20260411_120000.json"
+    create_session(sf, [{"id": 1, "title": "A"}], title="T", description="D")
+    mark_complete(sf, 1, "done")
+
+    result = oboe_trim_sessions(
+        base_dir=str(base_dir), before="2126-04-01T00:00:00+00:00",
+        dry_run=True,
+    )
+    assert not result.startswith("ERROR: "), result
+    assert json.loads(result)["deleted"] == [sf.name]
+
+

--- a/uv.lock
+++ b/uv.lock
@@ -314,6 +314,7 @@ version = "0.3.0"
 source = { editable = "." }
 dependencies = [
     { name = "mcp" },
+    { name = "pydantic" },
 ]
 
 [package.dev-dependencies]
@@ -323,7 +324,10 @@ dev = [
 ]
 
 [package.metadata]
-requires-dist = [{ name = "mcp", specifier = ">=2.0,<3" }]
+requires-dist = [
+    { name = "mcp", specifier = ">=2.0,<3" },
+    { name = "pydantic", specifier = ">=2.0,<3" },
+]
 
 [package.metadata.requires-dev]
 dev = [


### PR DESCRIPTION
Fixes #20, plus ten further defects found while reviewing the same code for the same bug class. Four of those lose data or leave a session unrecoverable.

Six commits, each self-contained and green on its own.

## The reported bug

`oboe_create` raised an unhandled `TypeError: unsupported operand type(s) for +: 'int' and 'str'` when an item's `dependencies` was a string. The message named neither the offending item nor the offending field. The issue asked for two independent fixes and both are here.

**Layer 1 — validate at the boundary.** `_recalc_priority` consumed the four score components straight from caller input. `validate_score_components()` now runs on every item before anything is written and rejects a bad value with `item 'example': 'dependencies' must be a number 0-5 (got str: '...')`. As a second layer the arithmetic itself checks each component's type, so no route in — including an old session file — yields a bare `TypeError`.

**Layer 2 — document the contract.** The `items` schema published by `oboe_create`, `oboe_merge_items` and `oboe_create_child_session` now types the four factors as `number` with `minimum: 0` / `maximum: 5`, and says `dependencies` is dependency *pressure* rather than a description of what the item depends on — the misreading its name invites. Tool descriptions, `docs/SESSION_FORMAT.md` and the `/obo` prompt say the same.

The 0-5 range is enforced on **input only**. Nothing ever bounded these values on disk, so applying it to the load path would make a previously readable session file unloadable.

## Data loss and unrecoverable state

- **`trim_sessions` deleted files outside the sessions directory.** It joined an `index.json` row's `file` onto the sessions directory and unlinked it, unchecked. A planted row of `../../IMPORTANT.txt` destroyed that file and still reported it as a deleted session. `index.json` is routinely committed and synced between machines, so its contents are not this code's to trust. Three independent checks now apply — filename pattern, bare-name, and resolved-parent containment, the last catching a symlink out of the tree. Refused rows are reported under `rejected`, and `deleted` lists what was actually unlinked.
- **`complete_child_session` could wedge a parent permanently.** It called `.get` on `blocker` without checking it was still a dict. After `oboe_update_field` had set it to a string, completing the child raised `AttributeError` — but only after the child was written completed, leaving the parent `paused` with a dangling `active_child_session` no tool could clear. Retrying failed identically.
- **`create_session` accepted duplicate ids where `merge_items` rejected them.** A shadowed item is unreachable, so the session could never complete, and `oboe_next(mark_in_progress=True)` returned one item and marked another.
- **A valid-looking `index.json` with non-dict rows crashed every write.** `_upsert_index` raised `TypeError` *after* the session file had been written, leaving session and index out of step on every mutating call.

## Crashes on well-formed or merely malformed input

- Mixed string/integer item ids crashed `oboe_next` and `oboe_list_items` on a `priority_score` tie; mixed-type `category` crashed `oboe-cli status`.
- `oboe_trim_sessions` raised `TypeError` on a timezone-aware `before`.
- A malformed session file was diagnosed as `dictionary update sequence element #0 has length 1` rather than by name.
- `oboe_update_field` could rewrite `id` into a collision and accepted any field name.

## Error boundaries

`_TOOL_EXCEPTIONS` omitted `KeyError`, `TypeError` and `AttributeError`, and 14 of 23 tools did not catch `KeyError` at all — which is why #20 surfaced as a raw interpreter message. All tools are now behind `_tool_boundary`, and `oboe-cli` reports domain errors as `❌ <message>` instead of a traceback (eight commands leaked one). The CLI boundary is deliberately *not* a blanket `except Exception`: unlike an MCP client, a CLI user is served by a traceback when something is genuinely a defect.

## Not reachable, fixed anyway

`atomic_write_json` was atomic but not durable (the rename was never fsynced); `migrate` truncated the user's own instruction files in place; and `oboe_set_lock_policy` compared `timeout_seconds <= 0` before type-checking it. The last had no reachable caller — pydantic coerces the MCP parameter and `oboe-cli` parses `--lock-timeout` itself — but reachability is a property of today's callers, not of whether the code is right.

## Bug-class propagation

Per `CONTRIBUTING.md`, each fix was greppped tree-wide for siblings and the result stated, including when clean:

| Class | Sites | Result |
| --- | --- | --- |
| Score arithmetic on unvalidated input | 68 | all routed through validation |
| Ordering heterogeneous caller values | 16 | 2 fixed (ids, categories); 14 clean |
| Access on a value of unguaranteed shape | 2 | both now guaranteed upstream |
| Filesystem mutation from a data-derived path | 10 | 1 fixed (`trim`); 9 derive from fixed roots |
| Adjacent function missing a sibling's guard | 4 | all fixed |

## Verification

- **513 tests pass** — 331 pre-existing unchanged, 182 new across eight files. Every new guard was confirmed to **fail against the unfixed code first**, by surgically reverting each fix rather than by assertion.
- Each of the six commits was **replayed in a clean worktree**: 410 → 433 → 442 → 458 → 490 → 513, so no commit in the series is broken.
- Adversarial sweeps of **all 23 MCP tools and 20 CLI invocations** under hostile input: zero raw exceptions, no files destroyed.
- `mypy` and `codespell` clean; wheel builds and both entry points smoke-tested from a clean resolve.
- `pydantic>=2.0,<3` is now declared rather than relied on transitively.

## Notes for review

- `migrate.py` duplicates the atomic-write routine rather than importing `locking.atomic_write_text`, deliberately: `migrate` is documented to run on the stock macOS `python3` (3.9), while `locking` evaluates `float | None` annotations at runtime and needs 3.10+. Importing it would break the repair tool on exactly the interpreter it was written to survive.
- `oboe_update_field` still accepts a numeric string for score components, because its `value` arrives from `argv` or a `str`-typed MCP parameter. The JSON item tools reject `"3"`, since their schema declares `number`. The asymmetry is intentional.
- `trim_sessions` gains `rejected` / `total_rejected` keys in its return value.
