### PR TITLE
ci(publish): default the publish target to pypi, not testpypi

### DIFF
--- a/.github/instructions/release-workflow.instructions.md
+++ b/.github/instructions/release-workflow.instructions.md
@@ -85,10 +85,26 @@ Publication goes through `publish.yml`, dispatched against `main`:
 gh workflow run publish.yml --ref main -f repository=pypi
 ```
 
-**Pass `repository=pypi` explicitly. The input defaults to `testpypi`**, and
-the two publish jobs are gated on that value — a bare
-`gh workflow run publish.yml` therefore publishes to the wrong index and
-reports success while doing so.
+`repository` **defaults to `pypi`**, so `-f repository=pypi` is redundant. It is
+written out anyway in the command above, and worth writing out yourself: the
+two publish jobs are gated on that value, and a release is a bad moment to be
+relying on a default you have not looked at.
+
+For the dry run, the flag is **not** optional:
+
+```bash
+gh workflow run publish.yml --ref main -f repository=testpypi
+```
+
+This default was `testpypi` until 0.4.0, on the reasoning that a safe default
+protects against an accidental real publish. That had the failure backwards.
+Publishing is the common dispatch and the dry run is rare — see below, it is
+called for only when this workflow file itself has changed — so the old default
+made the ordinary action require an extra flag, and omitting it published to
+the wrong index **and reported success**. The accidental-publish risk it was
+guarding is in any case bounded: `pypa/gh-action-pypi-publish` does not set
+`skip-existing`, so PyPI rejects a version that already exists and a stray
+dispatch against an unchanged `main` fails instead of shipping.
 
 This is preferred over `twine upload` from a workstation for three reasons: it
 authenticates by OIDC rather than a local API token, it attaches **provenance

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -4,13 +4,27 @@ on:
   workflow_dispatch:
     inputs:
       repository:
-        description: Publish target
+        # Defaults to pypi, the case this workflow is actually dispatched for.
+        #
+        # It defaulted to testpypi as a safety measure, which had the failure
+        # backwards. Publishing is deliberate and rare; the TestPyPI dry run is
+        # rarer still — the release instructions call for it only when this file
+        # itself has changed. So the old default made the COMMON action require
+        # an extra flag, and omitting that flag published to the wrong index
+        # AND REPORTED SUCCESS. A silent wrong outcome is worse than a loud one.
+        #
+        # The risk this inverts is bounded: pypa/gh-action-pypi-publish does not
+        # set skip-existing, so PyPI rejects a version that already exists. A
+        # stray dispatch against an unchanged main therefore fails rather than
+        # shipping anything. The only way to publish by accident is to have
+        # already bumped the version — i.e. to have been mid-release anyway.
+        description: Publish target (pypi is the real index; testpypi is a dry run)
         required: true
-        default: testpypi
+        default: pypi
         type: choice
         options:
-          - testpypi
           - pypi
+          - testpypi
   release:
     types:
       - published


### PR DESCRIPTION
The default was `testpypi` as a safety measure, and it had the failure backwards.

Publishing is the common dispatch; the TestPyPI dry run is rare — called for only when this workflow file itself has changed. So the old default made the **ordinary** action require an extra flag, and omitting that flag published to the wrong index **and reported success**. A silent wrong outcome is worse than a loud one.

## Why the inverted risk is acceptable

`pypa/gh-action-pypi-publish` does not set `skip-existing`, so **PyPI rejects a version that already exists**. A stray dispatch against an unchanged `main` fails rather than shipping. Publishing by accident requires having already bumped the version — i.e. being mid-release anyway.

## Also in this commit

Both documents that asserted the old default are corrected here, or this change would have made them wrong the moment it merged. The shared `/publish` prompt now tells the reader to **check** the default in the workflow rather than restating it, since that is a fact about one repository and the prompt is used across several.

Options reordered so `pypi` is first — for a `choice` input that is what a caller sees and what GitHub falls back to.

## Verified

YAML parses; `default: pypi`, `options: [pypi, testpypi]`, `required: true`; both job `if:` gates still reference the same two option values.

## Note for the next release

Per the dry-run policy in the same file, `publish.yml` having changed since `v0.4.0` is **exactly the condition that calls for a TestPyPI dry run** before the next publish. This PR creates that condition.